### PR TITLE
feat: Add server setup and management script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ out/
 .vscode/
 # OS cruft
 .DS_Store
+
+# MMOCraft Server
+/server/
+*.pid

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ MMOCraft is built on a collection of robust, interconnected systems.
 
 ## Getting Started
 
+Follow these steps to get the plugin running.
+
 1.  **Build the Plugin:**
     ```bash
     # Make sure the Gradle wrapper is executable
@@ -54,11 +56,36 @@ MMOCraft is built on a collection of robust, interconnected systems.
     # Build the shaded JAR
     ./gradlew build
     ```
-2.  **Install:**
-    *   Take the resulting JAR file from `build/libs/`. It will be named something like `MMOCraft-0.1.0-SNAPSHOT-all.jar`.
-    *   Drop this JAR into the `plugins` directory of a **Purpur 1.21.5** server.
-3.  **Run the Server:**
-    *   Start your server. The plugin will create its default configuration files in `/plugins/MMOCraft/`.
+    The final plugin JAR will be in the `build/libs/` directory.
+
+2.  **Set Up & Run the Server:**
+    The repository includes a convenient script to handle server setup and management.
+    ```bash
+    # Make the script executable (only needs to be done once)
+    chmod +x ./server.sh
+
+    # Start the server
+    ./server.sh start
+    ```
+    The first time you run this, the script will automatically:
+    *   Download the correct Purpur server JAR into a `server/` directory.
+    *   Accept the Minecraft EULA on your behalf.
+    *   Start the server.
+
+    The built plugin JAR from step 1 will need to be manually moved into the `server/plugins/` directory.
+
+## Server Management (`server.sh`)
+
+Use the `server.sh` script to manage your server lifecycle.
+
+| Command | Description |
+| --- | --- |
+| `./server.sh start` | Starts the server in the background. Performs initial setup if needed. |
+| `./server.sh stop` | Stops the running server. |
+| `./server.sh restart` | Restarts the server. |
+| `./server.sh status` | Checks if the server process is currently running. |
+| `./server.sh console` | Attaches to and tails the live server log (`logs/latest.log`). |
+| `./server.sh setup` | Manually runs the download and EULA acceptance process. |
 
 ## Configuration
 

--- a/server.sh
+++ b/server.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# --- Configuration ---
+MINECRAFT_VERSION="1.21.5"
+PURPUR_BUILD="2450" # The latest build for 1.21.5 as of writing
+SERVER_JAR_URL="https://api.purpurmc.org/v2/purpur/${MINECRAFT_VERSION}/${PURPUR_BUILD}/download"
+SERVER_DIR="server"
+JAR_NAME="purpur-${MINECRAFT_VERSION}-${PURPUR_BUILD}.jar"
+SERVER_JAR_PATH="${SERVER_DIR}/${JAR_NAME}"
+EULA_PATH="${SERVER_DIR}/eula.txt"
+PID_FILE="${SERVER_DIR}/server.pid"
+LOG_FILE="${SERVER_DIR}/logs/latest.log"
+
+# --- Java Settings ---
+MEMORY_ARGS="-Xms2G -Xmx2G" # 2GB initial and max heap size
+
+# --- Helper Functions ---
+function print_info {
+    echo "[INFO] $1"
+}
+
+function print_error {
+    echo "[ERROR] $1" >&2
+}
+
+function print_usage {
+    echo "Usage: $0 {start|stop|restart|status|console|setup}"
+    echo "  start   - Starts the server (will run setup if needed)."
+    echo "  stop    - Stops the server."
+    echo "  restart - Restarts the server."
+    echo "  status  - Checks if the server is running."
+    echo "  console - Attaches to the server console log."
+    echo "  setup   - Performs the initial server setup (download, eula)."
+}
+
+# --- Core Functions ---
+
+function setup_server {
+    print_info "Starting server setup..."
+    mkdir -p "${SERVER_DIR}"
+
+    if [ ! -f "$SERVER_JAR_PATH" ]; then
+        print_info "Purpur JAR not found. Downloading..."
+        if ! curl -L -o "$SERVER_JAR_PATH" "$SERVER_JAR_URL"; then
+            print_error "Failed to download Purpur JAR. Please check the URL or your internet connection."
+            exit 1
+        fi
+        print_info "Download complete."
+    else
+        print_info "Purpur JAR already exists."
+    fi
+
+    if [ ! -f "$EULA_PATH" ]; then
+        print_info "EULA not accepted. Creating eula.txt..."
+        echo "eula=true" > "$EULA_PATH"
+        print_info "EULA has been accepted."
+    else
+        print_info "eula.txt already exists."
+    fi
+    print_info "Setup complete."
+}
+
+function start_server {
+    if is_running; then
+        print_error "Server is already running."
+        exit 1
+    fi
+
+    if [ ! -f "$SERVER_JAR_PATH" ]; then
+        print_info "Server JAR not found. Running setup first."
+        setup_server
+    fi
+
+    cd "$SERVER_DIR" || exit
+    print_info "Starting Minecraft server..."
+    nohup java $MEMORY_ARGS -jar "$JAR_NAME" --nogui > /dev/null 2>&1 &
+    echo $! > "server.pid"
+    cd ..
+
+    sleep 5 # Give server time to start up a bit
+    if is_running; then
+        print_info "Server started successfully with PID $(cat $PID_FILE)."
+    else
+        print_error "Server failed to start. Check logs in ${SERVER_DIR}/logs/"
+    fi
+}
+
+function stop_server {
+    if ! is_running; then
+        print_error "Server is not running."
+        exit 1
+    fi
+
+    local pid
+    pid=$(cat "$PID_FILE")
+    print_info "Stopping server with PID $pid..."
+    kill "$pid"
+
+    # Wait for server to stop
+    local count=0
+    while is_running; do
+        sleep 1
+        count=$((count + 1))
+        if [ $count -gt 15 ]; then
+            print_error "Server did not stop gracefully after 15 seconds. Forcing shutdown..."
+            kill -9 "$pid"
+            break
+        fi
+    done
+
+    rm -f "$PID_FILE"
+    print_info "Server stopped."
+}
+
+function is_running {
+    if [ -f "$PID_FILE" ]; then
+        local pid
+        pid=$(cat "$PID_FILE")
+        if ps -p "$pid" > /dev/null; then
+            return 0 # Process is running
+        else
+            # PID file exists but process is not running, cleanup
+            rm -f "$PID_FILE"
+            return 1
+        fi
+    fi
+    return 1 # Not running
+}
+
+function server_status {
+    if is_running; then
+        print_info "Server is RUNNING with PID $(cat $PID_FILE)."
+    else
+        print_info "Server is STOPPED."
+    fi
+}
+
+function view_console {
+    if [ -f "$LOG_FILE" ]; then
+        tail -f "$LOG_FILE"
+    else
+        print_error "Log file not found. Is the server running for the first time?"
+    fi
+}
+
+
+# --- Main Logic ---
+case "$1" in
+    start)
+        start_server
+        ;;
+    stop)
+        stop_server
+        ;;
+    restart)
+        if is_running; then
+            stop_server
+        fi
+        start_server
+        ;;
+    status)
+        server_status
+        ;;
+    console)
+        view_console
+        ;;
+    setup)
+        setup_server
+        ;;
+    *)
+        print_usage
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
This commit introduces a new `server.sh` script to automate the setup and management of the Purpur server.

The script provides the following commands:
- `start`: Starts the server, performing a one-time setup (download JAR, accept EULA) if needed.
- `stop`: Stops the server process.
- `restart`: Restarts the server.
- `status`: Checks if the server is running.
- `console`: Tails the server's log file.
- `setup`: Manually triggers the setup process.

Additionally, this commit updates the `.gitignore` file to exclude the `server/` directory and `.pid` files. The `README.md` has also been updated to document the usage of the new script.