### PR TITLE
Fix: Add delay to restart command to prevent race condition

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -123,7 +123,7 @@ function start_server {
     print_info "Starting Minecraft server in screen session '$SCREEN_NAME'..."
     cd "$SERVER_DIR" || exit
     # Start server in a detached screen session
-    screen -S "$SCREEN_NAME" -d -m java $MEMORY_ARGS -jar "$JAR_NAME" --nogui
+    screen -L -Logfile "screen.log" -S "$SCREEN_NAME" -d -m java $MEMORY_ARGS -jar "$JAR_NAME" --nogui
     cd ..
 
     sleep 3
@@ -203,6 +203,8 @@ case "$1" in
     restart)
         if is_running; then
             stop_server
+        print_info "Waiting for 3 seconds before restarting..."
+        sleep 3
         fi
         start_server
         ;;

--- a/server/server.properties
+++ b/server/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Fri Sep 05 12:08:24 UTC 2025
+#Sun Sep 07 17:03:39 UTC 2025
 accepts-transfers=false
 allow-flight=false
 allow-nether=true


### PR DESCRIPTION
The server was failing to restart because the `server.sh` script was attempting to start a new server instance immediately after stopping the old one. This created a race condition where the operating system had not yet released the file lock on the SQLite database, causing the new server process to crash silently on startup.

This commit resolves the issue by adding a 3-second delay between the stop and start operations within the `restart` command in `server.sh`. This provides sufficient time for the OS to release resources and allows the server to restart reliably.

Additionally, screen logging has been enabled to capture server output to `server/screen.log`, which will aid in diagnosing any future startup issues.