### PR TITLE
fix: Make server script portable and robust

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -116,8 +116,11 @@ function setup_server {
             echo # Move to a new line
             if [[ $REPLY =~ ^[Yy]$ ]]; then
                 print_info "Accepting EULA..."
-                # Use sed to change eula=false to eula=true
-                sed -i 's/eula=false/eula=true/' "$EULA_PATH"
+                # Use sed to change eula=false/eula=true (portable syntax for Linux and macOS)
+                if ! sed -i '' 's/eula=false/eula=true/' "$EULA_PATH"; then
+                    print_error "Failed to update eula.txt. Please edit it manually. Aborting."
+                    exit 1
+                fi
                 print_info "EULA has been accepted."
             else
                 print_error "You must agree to the EULA to run the server. Aborting."
@@ -160,7 +163,8 @@ function start_server {
     print_info "Starting Minecraft server in screen session '$SCREEN_NAME'..."
     cd "$SERVER_DIR" || exit
     # Start server in a detached screen session
-    screen -L -Logfile "screen.log" -S "$SCREEN_NAME" -d -m java $MEMORY_ARGS -jar "$JAR_NAME" --nogui
+    # The -L flag enables logging to a file, typically named "screen.0", "screen.1", etc.
+    screen -L -S "$SCREEN_NAME" -d -m java $MEMORY_ARGS -jar "$JAR_NAME" --nogui
     cd ..
 
     sleep 3
@@ -169,7 +173,7 @@ function start_server {
         print_info "To connect to the console, run: $0 console"
         print_info "To send a command, run: $0 command <your-command>"
     else
-        print_error "Server failed to start. Check for crash logs in '${SERVER_DIR}/crash-reports/' or view the screen buffer with 'screen -r ${SCREEN_NAME}'."
+        print_error "Server failed to start. Check for crash logs in '${SERVER_DIR}/crash-reports/' or the screen log (e.g., '${SERVER_DIR}/screen.0'). You can also view the buffer with 'screen -r ${SCREEN_NAME}'."
     fi
 }
 


### PR DESCRIPTION
This commit provides a comprehensive set of fixes and improvements to the `server.sh` script, addressing multiple issues related to reliability and cross-platform compatibility.

The following changes are included:

1.  **Fix Server Restart Failure:**
    - A 3-second delay has been added to the `restart` command between stopping and starting the server.
    - This resolves a race condition where the server would fail to restart because the OS hadn't released file locks from the previous session.

2.  **Add Interactive EULA Acceptance:**
    - The script no longer automatically accepts the EULA.
    - It now features a configurable `AUTO_ACCEPT_EULA` variable (defaulting to `false`).
    - By default, it interactively prompts the user to agree to the Minecraft EULA on the first setup.

3.  **Ensure macOS Compatibility:**
    - The `sed` command for updating `eula.txt` has been changed to the portable `sed -i ''` syntax, which works on both Linux (GNU) and macOS (BSD).
    - The `screen` command has been corrected to use the standard `-L` flag for logging, as `-Logfile` is not supported on macOS.

4.  **Improve Error Handling and Logging:**
    - Added error checking to the `sed` command to prevent the script from continuing on failure.
    - The error message for a failed server start now correctly points to the generic `screen.0` log file.