### PR TITLE
Improve server bootstrap and SQLite lifecycle

### DIFF
--- a/src/main/java/com/x1f4r/mmocraft/persistence/SqlitePersistenceService.java
+++ b/src/main/java/com/x1f4r/mmocraft/persistence/SqlitePersistenceService.java
@@ -67,7 +67,8 @@ public class SqlitePersistenceService implements PersistenceService {
                                           "info_key TEXT NOT NULL UNIQUE," +
                                           "info_value TEXT NOT NULL" +
                                           ");";
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        Connection conn = getConnection();
+        try (Statement stmt = conn.createStatement()) {
             stmt.execute(createPluginInfoTableSql);
             this.log.info("Database initialized and 'plugin_info' table created/verified.");
 
@@ -103,8 +104,8 @@ public class SqlitePersistenceService implements PersistenceService {
 
     @Override
     public <T> Optional<T> executeQuerySingle(String sql, RowMapper<T> mapper, Object... params) throws SQLException {
-        try (Connection conn = getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        Connection conn = getConnection();
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
             setParameters(pstmt, params);
             try (ResultSet rs = pstmt.executeQuery()) {
                 if (rs.next()) {
@@ -118,8 +119,8 @@ public class SqlitePersistenceService implements PersistenceService {
     @Override
     public <T> List<T> executeQueryList(String sql, RowMapper<T> mapper, Object... params) throws SQLException {
         List<T> results = new ArrayList<>();
-        try (Connection conn = getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        Connection conn = getConnection();
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
             setParameters(pstmt, params);
             try (ResultSet rs = pstmt.executeQuery()) {
                 while (rs.next()) {
@@ -132,8 +133,8 @@ public class SqlitePersistenceService implements PersistenceService {
 
     @Override
     public int executeUpdate(String sql, Object... params) throws SQLException {
-        try (Connection conn = getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        Connection conn = getConnection();
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
             setParameters(pstmt, params);
             return pstmt.executeUpdate();
         }

--- a/src/main/java/com/x1f4r/mmocraft/world/resourcegathering/persistence/ResourceNodeRepository.java
+++ b/src/main/java/com/x1f4r/mmocraft/world/resourcegathering/persistence/ResourceNodeRepository.java
@@ -37,9 +37,11 @@ public class ResourceNodeRepository {
                 "respawn_at_millis INTEGER NOT NULL, " +
                 "PRIMARY KEY (world_uid, x, y, z)" +
                 ");";
-        try (Connection conn = persistenceService.getConnection();
-             Statement stmt = conn.createStatement()) {
-            stmt.execute(sql);
+        try {
+            Connection conn = persistenceService.getConnection();
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(sql);
+            }
             loggingUtil.info("'" + TABLE_NAME + "' table schema initialized successfully.");
         } catch (SQLException e) {
             loggingUtil.severe("Failed to initialize '" + TABLE_NAME + "' table schema.", e);
@@ -49,19 +51,21 @@ public class ResourceNodeRepository {
     public void saveOrUpdateNode(ActiveResourceNode node) {
         String sql = "REPLACE INTO " + TABLE_NAME + " (world_uid, x, y, z, node_type_id, is_depleted, respawn_at_millis) VALUES (?, ?, ?, ?, ?, ?, ?)";
 
-        try (Connection conn = persistenceService.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        try {
+            Connection conn = persistenceService.getConnection();
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
 
-            Location loc = node.getInternalLocation();
-            pstmt.setString(1, loc.getWorld().getUID().toString());
-            pstmt.setInt(2, loc.getBlockX());
-            pstmt.setInt(3, loc.getBlockY());
-            pstmt.setInt(4, loc.getBlockZ());
-            pstmt.setString(5, node.getNodeTypeId());
-            pstmt.setInt(6, node.isDepleted() ? 1 : 0);
-            pstmt.setLong(7, node.getRespawnAtMillis());
+                Location loc = node.getInternalLocation();
+                pstmt.setString(1, loc.getWorld().getUID().toString());
+                pstmt.setInt(2, loc.getBlockX());
+                pstmt.setInt(3, loc.getBlockY());
+                pstmt.setInt(4, loc.getBlockZ());
+                pstmt.setString(5, node.getNodeTypeId());
+                pstmt.setInt(6, node.isDepleted() ? 1 : 0);
+                pstmt.setLong(7, node.getRespawnAtMillis());
 
-            pstmt.executeUpdate();
+                pstmt.executeUpdate();
+            }
         } catch (SQLException e) {
             loggingUtil.severe("Failed to save or update resource node at " + node.getLocation(), e);
         }
@@ -71,33 +75,35 @@ public class ResourceNodeRepository {
         Map<Location, ActiveResourceNode> nodes = new HashMap<>();
         String sql = "SELECT * FROM " + TABLE_NAME;
 
-        try (Connection conn = persistenceService.getConnection();
-             Statement stmt = conn.createStatement();
-             ResultSet rs = stmt.executeQuery(sql)) {
+        try {
+            Connection conn = persistenceService.getConnection();
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery(sql)) {
 
-            while (rs.next()) {
-                try {
-                    UUID worldUid = UUID.fromString(rs.getString("world_uid"));
-                    int x = rs.getInt("x");
-                    int y = rs.getInt("y");
-                    int z = rs.getInt("z");
-                    String nodeTypeId = rs.getString("node_type_id");
-                    boolean isDepleted = rs.getInt("is_depleted") == 1;
-                    long respawnAtMillis = rs.getLong("respawn_at_millis");
+                while (rs.next()) {
+                    try {
+                        UUID worldUid = UUID.fromString(rs.getString("world_uid"));
+                        int x = rs.getInt("x");
+                        int y = rs.getInt("y");
+                        int z = rs.getInt("z");
+                        String nodeTypeId = rs.getString("node_type_id");
+                        boolean isDepleted = rs.getInt("is_depleted") == 1;
+                        long respawnAtMillis = rs.getLong("respawn_at_millis");
 
-                    if (Bukkit.getWorld(worldUid) == null) {
-                        loggingUtil.warning("Could not load resource node in world with UID " + worldUid + " because the world is not loaded. Skipping.");
-                        continue;
+                        if (Bukkit.getWorld(worldUid) == null) {
+                            loggingUtil.warning("Could not load resource node in world with UID " + worldUid + " because the world is not loaded. Skipping.");
+                            continue;
+                        }
+
+                        Location location = new Location(Bukkit.getWorld(worldUid), x, y, z);
+                        ActiveResourceNode node = new ActiveResourceNode(location, nodeTypeId);
+                        node.setDepleted(isDepleted);
+                        node.setRespawnAtMillis(respawnAtMillis);
+
+                        nodes.put(location, node);
+                    } catch (IllegalArgumentException e) {
+                        loggingUtil.warning("Could not parse world UID from database. Skipping resource node record.", e);
                     }
-
-                    Location location = new Location(Bukkit.getWorld(worldUid), x, y, z);
-                    ActiveResourceNode node = new ActiveResourceNode(location, nodeTypeId);
-                    node.setDepleted(isDepleted);
-                    node.setRespawnAtMillis(respawnAtMillis);
-
-                    nodes.put(location, node);
-                } catch (IllegalArgumentException e) {
-                    loggingUtil.warning("Could not parse world UID from database. Skipping resource node record.", e);
                 }
             }
             loggingUtil.info("Successfully loaded " + nodes.size() + " active resource nodes from the database.");
@@ -112,18 +118,20 @@ public class ResourceNodeRepository {
     public void deleteNode(ActiveResourceNode node) {
         String sql = "DELETE FROM " + TABLE_NAME + " WHERE world_uid = ? AND x = ? AND y = ? AND z = ?";
 
-        try (Connection conn = persistenceService.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        try {
+            Connection conn = persistenceService.getConnection();
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
 
-            Location loc = node.getInternalLocation();
-            pstmt.setString(1, loc.getWorld().getUID().toString());
-            pstmt.setInt(2, loc.getBlockX());
-            pstmt.setInt(3, loc.getBlockY());
-            pstmt.setInt(4, loc.getBlockZ());
+                Location loc = node.getInternalLocation();
+                pstmt.setString(1, loc.getWorld().getUID().toString());
+                pstmt.setInt(2, loc.getBlockX());
+                pstmt.setInt(3, loc.getBlockY());
+                pstmt.setInt(4, loc.getBlockZ());
 
-            int affectedRows = pstmt.executeUpdate();
-            if (affectedRows > 0) {
-                loggingUtil.debug("Successfully deleted node at " + node.getLocation() + " from the database.");
+                int affectedRows = pstmt.executeUpdate();
+                if (affectedRows > 0) {
+                    loggingUtil.debug("Successfully deleted node at " + node.getLocation() + " from the database.");
+                }
             }
         } catch (SQLException e) {
             loggingUtil.severe("Failed to delete resource node at " + node.getLocation(), e);


### PR DESCRIPTION
## Summary
- add a portable EULA writer, IPv4 JVM flag, and a Mojang download fallback to `server.sh`
- keep the SQLite connection alive across DAO calls so the log only reports a single connect/close cycle
- stop resource-node persistence from repeatedly opening and closing the shared database connection

## Testing
- ./gradlew clean build
- ./server.sh setup
- ./server.sh start
- ./server.sh stop

------
https://chatgpt.com/codex/tasks/task_e_68c99ecbe210832991054960cfdbf73a