### PR TITLE
Finalize runtime stat integration and stabilize tests

### DIFF
--- a/src/main/java/com/x1f4r/mmocraft/combat/service/BasicDamageCalculationService.java
+++ b/src/main/java/com/x1f4r/mmocraft/combat/service/BasicDamageCalculationService.java
@@ -2,16 +2,21 @@ package com.x1f4r.mmocraft.combat.service;
 
 import com.x1f4r.mmocraft.combat.model.DamageInstance;
 import com.x1f4r.mmocraft.combat.model.DamageType;
+import com.x1f4r.mmocraft.config.gameplay.GameplayConfigService;
+import com.x1f4r.mmocraft.config.gameplay.RuntimeStatConfig;
 import com.x1f4r.mmocraft.playerdata.PlayerDataService;
 import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
 import com.x1f4r.mmocraft.playerdata.model.Stat;
 import com.x1f4r.mmocraft.util.LoggingUtil;
+import com.x1f4r.mmocraft.world.spawning.service.BasicCustomSpawningService;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import org.bukkit.metadata.MetadataValue;
 import org.bukkit.projectiles.ProjectileSource;
 
+import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 
@@ -19,126 +24,162 @@ public class BasicDamageCalculationService implements DamageCalculationService {
 
     private final PlayerDataService playerDataService;
     private final LoggingUtil logger;
-    private final MobStatProvider mobStatProvider; // Added
+    private final MobStatProvider mobStatProvider;
+    private final GameplayConfigService gameplayConfigService;
     private final Random random = new Random();
 
-    // Example scaling factors (could be moved to config or PlayerProfile constants)
-    private static final double STRENGTH_DAMAGE_SCALING_PHYSICAL = 0.5;
-    private static final double INTELLIGENCE_DAMAGE_SCALING_MAGICAL = 0.7;
-    private static final double MOB_DEFENSE_REDUCTION_FACTOR = 0.04; // 4% damage reduction per defense point
-
-    public BasicDamageCalculationService(PlayerDataService playerDataService, LoggingUtil logger, MobStatProvider mobStatProvider) { // Added mobStatProvider
-        this.playerDataService = playerDataService;
-        this.logger = logger;
-        this.mobStatProvider = mobStatProvider; // Added
+    public BasicDamageCalculationService(PlayerDataService playerDataService,
+                                         LoggingUtil logger,
+                                         MobStatProvider mobStatProvider,
+                                         GameplayConfigService gameplayConfigService) {
+        this.playerDataService = Objects.requireNonNull(playerDataService, "playerDataService");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.mobStatProvider = Objects.requireNonNull(mobStatProvider, "mobStatProvider");
+        this.gameplayConfigService = Objects.requireNonNull(gameplayConfigService, "gameplayConfigService");
         logger.debug("BasicDamageCalculationService initialized with MobStatProvider.");
     }
 
     @Override
     public DamageInstance calculateDamage(Entity attacker, Entity victim, double initialBaseDamage, DamageType damageType) {
-        Entity actualAttacker = attacker;
-        // Resolve actual attacker if it's a projectile
-        if (attacker instanceof Projectile projectile) {
-            ProjectileSource shooter = projectile.getShooter();
-            if (shooter instanceof Entity) {
-                actualAttacker = (Entity) shooter;
-            }
-        }
-
-        UUID attackerId = (actualAttacker != null) ? actualAttacker.getUniqueId() : null;
+        Entity actualAttacker = resolveActualAttacker(attacker);
+        UUID attackerId = actualAttacker != null ? actualAttacker.getUniqueId() : null;
         UUID victimId = victim.getUniqueId();
 
-        PlayerProfile attackerProfile = null;
-        PlayerProfile victimProfile = null;
-        double currentDamage = initialBaseDamage; // Start with the raw damage passed in
+        PlayerProfile attackerProfile = attackerId != null ? playerDataService.getPlayerProfile(attackerId) : null;
+        PlayerProfile victimProfile = playerDataService.getPlayerProfile(victimId);
 
-        if (actualAttacker instanceof Player pAttacker) {
-            attackerProfile = playerDataService.getPlayerProfile(attackerId);
-            if (attackerProfile == null) {
-                 logger.warning("Attacker Player " + pAttacker.getName() + " has no PlayerProfile in cache. Using raw damage.");
-            }
-        } else if (actualAttacker instanceof LivingEntity) {
-            // Attacker is a Mob. Use MobStatProvider for its base attack if initialBaseDamage wasn't already set by listener from it.
-            // The listener now sets initialBaseDamage from MobStatProvider, so we don't need to re-fetch here.
-            // currentDamage is already mob's base attack.
+        if (actualAttacker instanceof Player && attackerProfile == null) {
+            logger.warning("Attacker Player " + actualAttacker.getName() + " has no PlayerProfile in cache. Using raw damage.");
+        }
+        if (victim instanceof Player && victimProfile == null) {
+            logger.warning("Victim Player " + victim.getName() + " has no PlayerProfile in cache. Will take damage without profile-based mitigation.");
         }
 
+        RuntimeStatConfig runtimeConfig = gameplayConfigService.getRuntimeStatConfig();
+        RuntimeStatConfig.CombatSettings combatConfig = runtimeConfig.getCombatSettings();
+        RuntimeStatConfig.MobScalingSettings mobScaling = runtimeConfig.getMobScalingSettings();
 
-        if (victim instanceof Player pVictim) {
-            victimProfile = playerDataService.getPlayerProfile(victimId);
-            if (victimProfile == null) {
-                logger.warning("Victim Player " + pVictim.getName() + " has no PlayerProfile in cache. Will take damage without profile-based mitigation.");
-            }
-        }
-
+        double currentDamage = initialBaseDamage;
         boolean isCriticalHit = false;
         boolean isEvaded = false;
-        String mitigationDetailsLog = "";
+        StringBuilder mitigationDetails = new StringBuilder();
 
-
-        // 1. Apply Attacker's Offensive Bonuses
-        if (attackerProfile != null) { // Attacker is Player with profile
+        if (attackerProfile != null) {
             if (damageType == DamageType.PHYSICAL) {
-                currentDamage += attackerProfile.getStatValue(Stat.STRENGTH) * STRENGTH_DAMAGE_SCALING_PHYSICAL;
+                currentDamage += attackerProfile.getStatValue(Stat.STRENGTH) * combatConfig.getStrengthPhysicalScaling();
             } else if (damageType == DamageType.MAGICAL) {
-                double abilityPowerMultiplier = 1.0 + (attackerProfile.getStatValue(Stat.ABILITY_POWER) / 100.0);
-                currentDamage += attackerProfile.getStatValue(Stat.INTELLIGENCE) * INTELLIGENCE_DAMAGE_SCALING_MAGICAL * abilityPowerMultiplier;
+                double abilityPowerMultiplier = 1.0 + (attackerProfile.getStatValue(Stat.ABILITY_POWER)
+                        * combatConfig.getAbilityPowerPercentPerPoint() / 100.0);
+                currentDamage += attackerProfile.getStatValue(Stat.INTELLIGENCE)
+                        * combatConfig.getIntelligenceMagicalScaling() * abilityPowerMultiplier;
             }
-            // Critical Hit Check for players
             if (random.nextDouble() < attackerProfile.getCriticalHitChance()) {
                 isCriticalHit = true;
                 currentDamage *= attackerProfile.getCriticalDamageBonus();
             }
         }
-        // Note: Mobs currently don't have offensive stat scaling or crits in this basic system.
-        // Their `initialBaseDamage` (from MobStatProvider via listener) is their full base hit.
 
-        double damageAfterOffensiveBonuses = currentDamage; // This is what DamageInstance will store as 'baseDamage'
-
-        // 2. Apply Victim's Defensive Capabilities
-        // Evasion Check (Players only for now)
-        if (victimProfile != null) {
-            if (random.nextDouble() < victimProfile.getEvasionChance()) {
-                isEvaded = true;
-                currentDamage = 0;
-                mitigationDetailsLog += "Evaded. ";
+        if (victimProfile != null && actualAttacker instanceof LivingEntity && !(actualAttacker instanceof Player)) {
+            double levelFactor = Math.max(0, victimProfile.getLevel() - 1);
+            double scaling = 1.0 + (levelFactor * mobScaling.getDamagePerLevelPercent());
+            scaling = Math.min(scaling, mobScaling.getMaxDamageMultiplier());
+            if (scaling > 1.0) {
+                mitigationDetails.append(String.format("MobScale:+%.0f%%. ", (scaling - 1) * 100));
             }
+            currentDamage *= scaling;
         }
-        // No evasion for mobs yet.
 
-        // Damage Reduction
+        double damageAfterOffensiveBonuses = currentDamage;
+
+        if (victimProfile != null && random.nextDouble() < victimProfile.getEvasionChance()) {
+            isEvaded = true;
+            currentDamage = 0;
+            mitigationDetails.append("Evaded. ");
+        }
+
         if (!isEvaded && damageType != DamageType.TRUE) {
-            if (victimProfile != null) { // Victim is Player with profile
-                double reductionPercent = 0;
-                if (damageType == DamageType.PHYSICAL) {
-                    reductionPercent = victimProfile.getPhysicalDamageReduction();
-                    mitigationDetailsLog += String.format("P.Reduc:%.1f%%. ", reductionPercent * 100);
-                } else if (damageType == DamageType.MAGICAL) {
-                    reductionPercent = victimProfile.getMagicDamageReduction();
-                    mitigationDetailsLog += String.format("M.Reduc:%.1f%%. ", reductionPercent * 100);
+            if (victimProfile != null) {
+                double reductionPercent = damageType == DamageType.PHYSICAL
+                        ? victimProfile.getPhysicalDamageReduction()
+                        : victimProfile.getMagicDamageReduction();
+                if (reductionPercent > 0) {
+                    mitigationDetails.append(String.format("%sReduc:%.1f%%. ",
+                            damageType == DamageType.PHYSICAL ? "P." : "M.", reductionPercent * 100));
                 }
                 currentDamage *= (1.0 - reductionPercent);
-            } else if (victim instanceof LivingEntity && !(victim instanceof Player)) { // Victim is a Mob
-                double mobDefense = mobStatProvider.getBaseDefense(victim.getType());
-                double mobReduction = Math.min(0.95, mobDefense * MOB_DEFENSE_REDUCTION_FACTOR); // Cap reduction at 95%
-                mitigationDetailsLog += String.format("MobDefReduc:%.1f%% (Def:%.0f). ", mobReduction * 100, mobDefense);
+            } else if (victim instanceof LivingEntity livingVictim) {
+                double mobDefense = getMetadataDouble(livingVictim, BasicCustomSpawningService.METADATA_KEY_SCALED_DEFENSE);
+                if (Double.isNaN(mobDefense)) {
+                    mobDefense = mobStatProvider.getBaseDefense(livingVictim.getType());
+                    if (attackerProfile != null) {
+                        double levelFactor = Math.max(0, attackerProfile.getLevel() - 1);
+                        mobDefense = Math.min(mobDefense + (levelFactor * mobScaling.getDefensePerLevel()),
+                                mobScaling.getMaxDefenseBonus());
+                    }
+                }
+                double mobReduction = Math.min(0.95, Math.max(0.0, mobDefense) * combatConfig.getMobDefenseReductionFactor());
+                if (mobReduction > 0) {
+                    mitigationDetails.append(String.format("MobDefReduc:%.1f%% (Def:%.0f). ", mobReduction * 100, mobDefense));
+                }
                 currentDamage *= (1.0 - mobReduction);
             }
         }
 
-        double finalDamage = Math.max(0, currentDamage); // Ensure damage is not negative
-        if (isEvaded) finalDamage = 0;
+        double mitigatedDamage = Math.max(0, currentDamage);
+        double ferocityBonus = 0.0;
+        if (!isEvaded && attackerProfile != null) {
+            double ferocity = attackerProfile.getStatValue(Stat.FEROCITY);
+            double perHit = combatConfig.getFerocityPerExtraHit();
+            if (perHit > 0 && ferocity > 0) {
+                int guaranteedHits = (int) Math.floor(ferocity / perHit);
+                double remainderChance = (ferocity % perHit) / perHit;
+                int extraHits = Math.min(guaranteedHits, combatConfig.getFerocityMaxExtraHits());
+                if (random.nextDouble() < remainderChance && extraHits < combatConfig.getFerocityMaxExtraHits()) {
+                    extraHits++;
+                }
+                if (extraHits > 0) {
+                    ferocityBonus = mitigatedDamage * extraHits;
+                    mitigationDetails.append("Ferocity:").append(extraHits).append("x. ");
+                }
+            }
+        }
+
+        double finalDamage = isEvaded ? 0 : Math.max(0, mitigatedDamage + ferocityBonus);
 
         return new DamageInstance(
                 actualAttacker, victim,
                 attackerId, victimId,
                 attackerProfile, victimProfile,
-                damageAfterOffensiveBonuses, // Store damage after attacker's bonuses as 'base' for the instance
+                damageAfterOffensiveBonuses,
                 damageType,
                 isCriticalHit,
                 isEvaded,
-                mitigationDetailsLog.trim(),
+                mitigationDetails.toString().trim(),
                 finalDamage
         );
+    }
+
+    private Entity resolveActualAttacker(Entity attacker) {
+        Entity actualAttacker = attacker;
+        if (attacker instanceof Projectile projectile) {
+            ProjectileSource shooter = projectile.getShooter();
+            if (shooter instanceof Entity shooterEntity) {
+                actualAttacker = shooterEntity;
+            }
+        }
+        return actualAttacker;
+    }
+
+    private double getMetadataDouble(Entity entity, String key) {
+        if (entity == null || !entity.hasMetadata(key)) {
+            return Double.NaN;
+        }
+        for (MetadataValue metadataValue : entity.getMetadata(key)) {
+            Object value = metadataValue.value();
+            if (value instanceof Number number) {
+                return number.doubleValue();
+            }
+        }
+        return Double.NaN;
     }
 }

--- a/src/main/java/com/x1f4r/mmocraft/command/commands/ExecuteSkillCommand.java
+++ b/src/main/java/com/x1f4r/mmocraft/command/commands/ExecuteSkillCommand.java
@@ -71,13 +71,15 @@ public class ExecuteSkillCommand extends AbstractPluginCommand {
         Skill skill = optionalSkill.get();
 
         // --- Pre-Execution Checks ---
+        double effectiveManaCost = skill.getEffectiveManaCost(casterProfile);
+
         if (!skill.canUse(casterProfile)) {
             if (casterProfile.isSkillOnCooldown(skillId)) {
                 long remainingMillis = casterProfile.getSkillRemainingCooldown(skillId);
                 double remainingSeconds = remainingMillis / 1000.0;
                 casterPlayer.sendMessage(StringUtil.colorize("&c" + skill.getSkillName() + " is on cooldown for " + String.format("%.1f", remainingSeconds) + "s."));
-            } else if (casterProfile.getCurrentMana() < skill.getManaCost()) {
-                casterPlayer.sendMessage(StringUtil.colorize("&cNot enough mana for " + skill.getSkillName() + ". (Need " + skill.getManaCost() + ")"));
+            } else if (casterProfile.getCurrentMana() < Math.ceil(effectiveManaCost)) {
+                casterPlayer.sendMessage(StringUtil.colorize("&cNot enough mana for " + skill.getSkillName() + ". (Need " + String.format("%.1f", effectiveManaCost) + ")"));
             } else {
                  casterPlayer.sendMessage(StringUtil.colorize("&cYou cannot use " + skill.getSkillName() + " right now."));
             }

--- a/src/main/java/com/x1f4r/mmocraft/config/gameplay/RuntimeStatConfig.java
+++ b/src/main/java/com/x1f4r/mmocraft/config/gameplay/RuntimeStatConfig.java
@@ -1,0 +1,648 @@
+package com.x1f4r.mmocraft.config.gameplay;
+
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Runtime gameplay configuration that controls how calculated stats are
+ * translated into tangible in-game effects such as movement speed, attack
+ * cadence, ability resource consumption, gathering throughput and mob scaling.
+ */
+public final class RuntimeStatConfig {
+
+    private final MovementSettings movementSettings;
+    private final CombatSettings combatSettings;
+    private final AbilitySettings abilitySettings;
+    private final GatheringSettings gatheringSettings;
+    private final MobScalingSettings mobScalingSettings;
+
+    private RuntimeStatConfig(Builder builder) {
+        this.movementSettings = builder.movementSettingsBuilder.build();
+        this.combatSettings = builder.combatSettingsBuilder.build();
+        this.abilitySettings = builder.abilitySettingsBuilder.build();
+        this.gatheringSettings = builder.gatheringSettingsBuilder.build();
+        this.mobScalingSettings = builder.mobScalingSettingsBuilder.build();
+    }
+
+    public MovementSettings getMovementSettings() {
+        return movementSettings;
+    }
+
+    public CombatSettings getCombatSettings() {
+        return combatSettings;
+    }
+
+    public AbilitySettings getAbilitySettings() {
+        return abilitySettings;
+    }
+
+    public GatheringSettings getGatheringSettings() {
+        return gatheringSettings;
+    }
+
+    public MobScalingSettings getMobScalingSettings() {
+        return mobScalingSettings;
+    }
+
+    public static RuntimeStatConfig defaults() {
+        return builder().build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        Builder builder = new Builder();
+        builder.movementSettingsBuilder = movementSettings.toBuilder();
+        builder.combatSettingsBuilder = combatSettings.toBuilder();
+        builder.abilitySettingsBuilder = abilitySettings.toBuilder();
+        builder.gatheringSettingsBuilder = gatheringSettings.toBuilder();
+        builder.mobScalingSettingsBuilder = mobScalingSettings.toBuilder();
+        return builder;
+    }
+
+    public static final class Builder {
+        private MovementSettings.Builder movementSettingsBuilder = MovementSettings.builder();
+        private CombatSettings.Builder combatSettingsBuilder = CombatSettings.builder();
+        private AbilitySettings.Builder abilitySettingsBuilder = AbilitySettings.builder();
+        private GatheringSettings.Builder gatheringSettingsBuilder = GatheringSettings.builder();
+        private MobScalingSettings.Builder mobScalingSettingsBuilder = MobScalingSettings.builder();
+
+        private Builder() {
+        }
+
+        public Builder movementSettings(MovementSettings.Builder builder) {
+            this.movementSettingsBuilder = Objects.requireNonNull(builder, "movementSettingsBuilder");
+            return this;
+        }
+
+        public Builder combatSettings(CombatSettings.Builder builder) {
+            this.combatSettingsBuilder = Objects.requireNonNull(builder, "combatSettingsBuilder");
+            return this;
+        }
+
+        public Builder abilitySettings(AbilitySettings.Builder builder) {
+            this.abilitySettingsBuilder = Objects.requireNonNull(builder, "abilitySettingsBuilder");
+            return this;
+        }
+
+        public Builder gatheringSettings(GatheringSettings.Builder builder) {
+            this.gatheringSettingsBuilder = Objects.requireNonNull(builder, "gatheringSettingsBuilder");
+            return this;
+        }
+
+        public Builder mobScalingSettings(MobScalingSettings.Builder builder) {
+            this.mobScalingSettingsBuilder = Objects.requireNonNull(builder, "mobScalingSettingsBuilder");
+            return this;
+        }
+
+        public RuntimeStatConfig build() {
+            return new RuntimeStatConfig(this);
+        }
+    }
+
+    public static final class MovementSettings {
+        private final double baseWalkSpeed;
+        private final double maxWalkSpeed;
+        private final double minWalkSpeed;
+        private final double speedBaseline;
+
+        private MovementSettings(Builder builder) {
+            this.baseWalkSpeed = builder.baseWalkSpeed;
+            this.maxWalkSpeed = builder.maxWalkSpeed;
+            this.minWalkSpeed = builder.minWalkSpeed;
+            this.speedBaseline = builder.speedBaseline;
+        }
+
+        public double getBaseWalkSpeed() {
+            return baseWalkSpeed;
+        }
+
+        public double getMaxWalkSpeed() {
+            return maxWalkSpeed;
+        }
+
+        public double getMinWalkSpeed() {
+            return minWalkSpeed;
+        }
+
+        public double getSpeedBaseline() {
+            return speedBaseline;
+        }
+
+        public Builder toBuilder() {
+            return builder()
+                    .baseWalkSpeed(baseWalkSpeed)
+                    .maxWalkSpeed(maxWalkSpeed)
+                    .minWalkSpeed(minWalkSpeed)
+                    .speedBaseline(speedBaseline);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+            private double baseWalkSpeed = 0.2;
+            private double maxWalkSpeed = 0.7;
+            private double minWalkSpeed = 0.05;
+            private double speedBaseline = 100.0;
+
+            private Builder() {
+            }
+
+            public Builder baseWalkSpeed(double value) {
+                this.baseWalkSpeed = value;
+                return this;
+            }
+
+            public Builder maxWalkSpeed(double value) {
+                this.maxWalkSpeed = value;
+                return this;
+            }
+
+            public Builder minWalkSpeed(double value) {
+                this.minWalkSpeed = value;
+                return this;
+            }
+
+            public Builder speedBaseline(double value) {
+                this.speedBaseline = value;
+                return this;
+            }
+
+            public MovementSettings build() {
+                return new MovementSettings(this);
+            }
+        }
+    }
+
+    public static final class CombatSettings {
+        private final double baseAttackSpeed;
+        private final double attackSpeedPerPoint;
+        private final double maxAttackSpeed;
+        private final double strengthPhysicalScaling;
+        private final double intelligenceMagicalScaling;
+        private final double abilityPowerPercentPerPoint;
+        private final double ferocityPerExtraHit;
+        private final int ferocityMaxExtraHits;
+        private final double mobDefenseReductionFactor;
+
+        private CombatSettings(Builder builder) {
+            this.baseAttackSpeed = builder.baseAttackSpeed;
+            this.attackSpeedPerPoint = builder.attackSpeedPerPoint;
+            this.maxAttackSpeed = builder.maxAttackSpeed;
+            this.strengthPhysicalScaling = builder.strengthPhysicalScaling;
+            this.intelligenceMagicalScaling = builder.intelligenceMagicalScaling;
+            this.abilityPowerPercentPerPoint = builder.abilityPowerPercentPerPoint;
+            this.ferocityPerExtraHit = builder.ferocityPerExtraHit;
+            this.ferocityMaxExtraHits = builder.ferocityMaxExtraHits;
+            this.mobDefenseReductionFactor = builder.mobDefenseReductionFactor;
+        }
+
+        public double getBaseAttackSpeed() {
+            return baseAttackSpeed;
+        }
+
+        public double getAttackSpeedPerPoint() {
+            return attackSpeedPerPoint;
+        }
+
+        public double getMaxAttackSpeed() {
+            return maxAttackSpeed;
+        }
+
+        public double getStrengthPhysicalScaling() {
+            return strengthPhysicalScaling;
+        }
+
+        public double getIntelligenceMagicalScaling() {
+            return intelligenceMagicalScaling;
+        }
+
+        public double getAbilityPowerPercentPerPoint() {
+            return abilityPowerPercentPerPoint;
+        }
+
+        public double getFerocityPerExtraHit() {
+            return ferocityPerExtraHit;
+        }
+
+        public int getFerocityMaxExtraHits() {
+            return ferocityMaxExtraHits;
+        }
+
+        public double getMobDefenseReductionFactor() {
+            return mobDefenseReductionFactor;
+        }
+
+        public Builder toBuilder() {
+            return builder()
+                    .baseAttackSpeed(baseAttackSpeed)
+                    .attackSpeedPerPoint(attackSpeedPerPoint)
+                    .maxAttackSpeed(maxAttackSpeed)
+                    .strengthPhysicalScaling(strengthPhysicalScaling)
+                    .intelligenceMagicalScaling(intelligenceMagicalScaling)
+                    .abilityPowerPercentPerPoint(abilityPowerPercentPerPoint)
+                    .ferocityPerExtraHit(ferocityPerExtraHit)
+                    .ferocityMaxExtraHits(ferocityMaxExtraHits)
+                    .mobDefenseReductionFactor(mobDefenseReductionFactor);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+            private double baseAttackSpeed = 4.0;
+            private double attackSpeedPerPoint = 0.02;
+            private double maxAttackSpeed = 8.0;
+            private double strengthPhysicalScaling = 0.5;
+            private double intelligenceMagicalScaling = 0.7;
+            private double abilityPowerPercentPerPoint = 1.0;
+            private double ferocityPerExtraHit = 100.0;
+            private int ferocityMaxExtraHits = 4;
+            private double mobDefenseReductionFactor = 0.04;
+
+            private Builder() {
+            }
+
+            public Builder baseAttackSpeed(double value) {
+                this.baseAttackSpeed = value;
+                return this;
+            }
+
+            public Builder attackSpeedPerPoint(double value) {
+                this.attackSpeedPerPoint = value;
+                return this;
+            }
+
+            public Builder maxAttackSpeed(double value) {
+                this.maxAttackSpeed = value;
+                return this;
+            }
+
+            public Builder strengthPhysicalScaling(double value) {
+                this.strengthPhysicalScaling = value;
+                return this;
+            }
+
+            public Builder intelligenceMagicalScaling(double value) {
+                this.intelligenceMagicalScaling = value;
+                return this;
+            }
+
+            public Builder abilityPowerPercentPerPoint(double value) {
+                this.abilityPowerPercentPerPoint = value;
+                return this;
+            }
+
+            public Builder ferocityPerExtraHit(double value) {
+                this.ferocityPerExtraHit = value;
+                return this;
+            }
+
+            public Builder ferocityMaxExtraHits(int value) {
+                this.ferocityMaxExtraHits = value;
+                return this;
+            }
+
+            public Builder mobDefenseReductionFactor(double value) {
+                this.mobDefenseReductionFactor = value;
+                return this;
+            }
+
+            public CombatSettings build() {
+                return new CombatSettings(this);
+            }
+        }
+    }
+
+    public static final class AbilitySettings {
+        private final double cooldownReductionPerAttackSpeedPoint;
+        private final double cooldownReductionPerIntelligencePoint;
+        private final double minimumCooldownSeconds;
+        private final double manaCostReductionPerIntelligencePoint;
+        private final double manaCostReductionPerAbilityPowerPoint;
+        private final double minimumManaCostMultiplier;
+        private final double minimumManaCost;
+
+        private AbilitySettings(Builder builder) {
+            this.cooldownReductionPerAttackSpeedPoint = builder.cooldownReductionPerAttackSpeedPoint;
+            this.cooldownReductionPerIntelligencePoint = builder.cooldownReductionPerIntelligencePoint;
+            this.minimumCooldownSeconds = builder.minimumCooldownSeconds;
+            this.manaCostReductionPerIntelligencePoint = builder.manaCostReductionPerIntelligencePoint;
+            this.manaCostReductionPerAbilityPowerPoint = builder.manaCostReductionPerAbilityPowerPoint;
+            this.minimumManaCostMultiplier = builder.minimumManaCostMultiplier;
+            this.minimumManaCost = builder.minimumManaCost;
+        }
+
+        public double getCooldownReductionPerAttackSpeedPoint() {
+            return cooldownReductionPerAttackSpeedPoint;
+        }
+
+        public double getCooldownReductionPerIntelligencePoint() {
+            return cooldownReductionPerIntelligencePoint;
+        }
+
+        public double getMinimumCooldownSeconds() {
+            return minimumCooldownSeconds;
+        }
+
+        public double getManaCostReductionPerIntelligencePoint() {
+            return manaCostReductionPerIntelligencePoint;
+        }
+
+        public double getManaCostReductionPerAbilityPowerPoint() {
+            return manaCostReductionPerAbilityPowerPoint;
+        }
+
+        public double getMinimumManaCostMultiplier() {
+            return minimumManaCostMultiplier;
+        }
+
+        public double getMinimumManaCost() {
+            return minimumManaCost;
+        }
+
+        public Builder toBuilder() {
+            return builder()
+                    .cooldownReductionPerAttackSpeedPoint(cooldownReductionPerAttackSpeedPoint)
+                    .cooldownReductionPerIntelligencePoint(cooldownReductionPerIntelligencePoint)
+                    .minimumCooldownSeconds(minimumCooldownSeconds)
+                    .manaCostReductionPerIntelligencePoint(manaCostReductionPerIntelligencePoint)
+                    .manaCostReductionPerAbilityPowerPoint(manaCostReductionPerAbilityPowerPoint)
+                    .minimumManaCostMultiplier(minimumManaCostMultiplier)
+                    .minimumManaCost(minimumManaCost);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+            private double cooldownReductionPerAttackSpeedPoint = 0.002;
+            private double cooldownReductionPerIntelligencePoint = 0.0;
+            private double minimumCooldownSeconds = 0.2;
+            private double manaCostReductionPerIntelligencePoint = 0.001;
+            private double manaCostReductionPerAbilityPowerPoint = 0.001;
+            private double minimumManaCostMultiplier = 0.2;
+            private double minimumManaCost = 1.0;
+
+            private Builder() {
+            }
+
+            public Builder cooldownReductionPerAttackSpeedPoint(double value) {
+                this.cooldownReductionPerAttackSpeedPoint = value;
+                return this;
+            }
+
+            public Builder cooldownReductionPerIntelligencePoint(double value) {
+                this.cooldownReductionPerIntelligencePoint = value;
+                return this;
+            }
+
+            public Builder minimumCooldownSeconds(double value) {
+                this.minimumCooldownSeconds = value;
+                return this;
+            }
+
+            public Builder manaCostReductionPerIntelligencePoint(double value) {
+                this.manaCostReductionPerIntelligencePoint = value;
+                return this;
+            }
+
+            public Builder manaCostReductionPerAbilityPowerPoint(double value) {
+                this.manaCostReductionPerAbilityPowerPoint = value;
+                return this;
+            }
+
+            public Builder minimumManaCostMultiplier(double value) {
+                this.minimumManaCostMultiplier = value;
+                return this;
+            }
+
+            public Builder minimumManaCost(double value) {
+                this.minimumManaCost = value;
+                return this;
+            }
+
+            public AbilitySettings build() {
+                return new AbilitySettings(this);
+            }
+        }
+    }
+
+    public static final class GatheringSettings {
+        private final double baseGatherDelaySeconds;
+        private final double minimumGatherDelaySeconds;
+        private final double miningSpeedDelayDivisor;
+        private final double miningSpeedHastePerTier;
+        private final int miningSpeedMaxHasteTier;
+        private final Map<Stat, Double> fortunePerPoint;
+
+        private GatheringSettings(Builder builder) {
+            this.baseGatherDelaySeconds = builder.baseGatherDelaySeconds;
+            this.minimumGatherDelaySeconds = builder.minimumGatherDelaySeconds;
+            this.miningSpeedDelayDivisor = builder.miningSpeedDelayDivisor;
+            this.miningSpeedHastePerTier = builder.miningSpeedHastePerTier;
+            this.miningSpeedMaxHasteTier = builder.miningSpeedMaxHasteTier;
+            this.fortunePerPoint = Map.copyOf(builder.fortunePerPoint);
+        }
+
+        public double getBaseGatherDelaySeconds() {
+            return baseGatherDelaySeconds;
+        }
+
+        public double getMinimumGatherDelaySeconds() {
+            return minimumGatherDelaySeconds;
+        }
+
+        public double getMiningSpeedDelayDivisor() {
+            return miningSpeedDelayDivisor;
+        }
+
+        public double getMiningSpeedHastePerTier() {
+            return miningSpeedHastePerTier;
+        }
+
+        public int getMiningSpeedMaxHasteTier() {
+            return miningSpeedMaxHasteTier;
+        }
+
+        public double getFortunePerPoint(Stat stat) {
+            return fortunePerPoint.getOrDefault(stat, 0.0);
+        }
+
+        public Builder toBuilder() {
+            Builder builder = builder()
+                    .baseGatherDelaySeconds(baseGatherDelaySeconds)
+                    .minimumGatherDelaySeconds(minimumGatherDelaySeconds)
+                    .miningSpeedDelayDivisor(miningSpeedDelayDivisor)
+                    .miningSpeedHastePerTier(miningSpeedHastePerTier)
+                    .miningSpeedMaxHasteTier(miningSpeedMaxHasteTier);
+            builder.fortunePerPoint.putAll(this.fortunePerPoint);
+            return builder;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+            private double baseGatherDelaySeconds = 1.0;
+            private double minimumGatherDelaySeconds = 0.25;
+            private double miningSpeedDelayDivisor = 100.0;
+            private double miningSpeedHastePerTier = 80.0;
+            private int miningSpeedMaxHasteTier = 4;
+            private final Map<Stat, Double> fortunePerPoint = new EnumMap<>(Stat.class);
+
+            private Builder() {
+                fortunePerPoint.put(Stat.MINING_FORTUNE, 0.002);
+                fortunePerPoint.put(Stat.FARMING_FORTUNE, 0.002);
+                fortunePerPoint.put(Stat.FORAGING_FORTUNE, 0.002);
+                fortunePerPoint.put(Stat.FISHING_FORTUNE, 0.0015);
+            }
+
+            public Builder baseGatherDelaySeconds(double value) {
+                this.baseGatherDelaySeconds = value;
+                return this;
+            }
+
+            public Builder minimumGatherDelaySeconds(double value) {
+                this.minimumGatherDelaySeconds = value;
+                return this;
+            }
+
+            public Builder miningSpeedDelayDivisor(double value) {
+                this.miningSpeedDelayDivisor = value;
+                return this;
+            }
+
+            public Builder miningSpeedHastePerTier(double value) {
+                this.miningSpeedHastePerTier = value;
+                return this;
+            }
+
+            public Builder miningSpeedMaxHasteTier(int value) {
+                this.miningSpeedMaxHasteTier = value;
+                return this;
+            }
+
+            public Builder fortunePerPoint(Stat stat, double value) {
+                this.fortunePerPoint.put(Objects.requireNonNull(stat), value);
+                return this;
+            }
+
+            public GatheringSettings build() {
+                return new GatheringSettings(this);
+            }
+        }
+    }
+
+    public static final class MobScalingSettings {
+        private final double healthPerLevelPercent;
+        private final double damagePerLevelPercent;
+        private final double defensePerLevel;
+        private final double maxHealthMultiplier;
+        private final double maxDamageMultiplier;
+        private final double maxDefenseBonus;
+
+        private MobScalingSettings(Builder builder) {
+            this.healthPerLevelPercent = builder.healthPerLevelPercent;
+            this.damagePerLevelPercent = builder.damagePerLevelPercent;
+            this.defensePerLevel = builder.defensePerLevel;
+            this.maxHealthMultiplier = builder.maxHealthMultiplier;
+            this.maxDamageMultiplier = builder.maxDamageMultiplier;
+            this.maxDefenseBonus = builder.maxDefenseBonus;
+        }
+
+        public double getHealthPerLevelPercent() {
+            return healthPerLevelPercent;
+        }
+
+        public double getDamagePerLevelPercent() {
+            return damagePerLevelPercent;
+        }
+
+        public double getDefensePerLevel() {
+            return defensePerLevel;
+        }
+
+        public double getMaxHealthMultiplier() {
+            return maxHealthMultiplier;
+        }
+
+        public double getMaxDamageMultiplier() {
+            return maxDamageMultiplier;
+        }
+
+        public double getMaxDefenseBonus() {
+            return maxDefenseBonus;
+        }
+
+        public Builder toBuilder() {
+            return builder()
+                    .healthPerLevelPercent(healthPerLevelPercent)
+                    .damagePerLevelPercent(damagePerLevelPercent)
+                    .defensePerLevel(defensePerLevel)
+                    .maxHealthMultiplier(maxHealthMultiplier)
+                    .maxDamageMultiplier(maxDamageMultiplier)
+                    .maxDefenseBonus(maxDefenseBonus);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+            private double healthPerLevelPercent = 0.05;
+            private double damagePerLevelPercent = 0.03;
+            private double defensePerLevel = 0.5;
+            private double maxHealthMultiplier = 5.0;
+            private double maxDamageMultiplier = 5.0;
+            private double maxDefenseBonus = 200.0;
+
+            private Builder() {
+            }
+
+            public Builder healthPerLevelPercent(double value) {
+                this.healthPerLevelPercent = value;
+                return this;
+            }
+
+            public Builder damagePerLevelPercent(double value) {
+                this.damagePerLevelPercent = value;
+                return this;
+            }
+
+            public Builder defensePerLevel(double value) {
+                this.defensePerLevel = value;
+                return this;
+            }
+
+            public Builder maxHealthMultiplier(double value) {
+                this.maxHealthMultiplier = value;
+                return this;
+            }
+
+            public Builder maxDamageMultiplier(double value) {
+                this.maxDamageMultiplier = value;
+                return this;
+            }
+
+            public Builder maxDefenseBonus(double value) {
+                this.maxDefenseBonus = value;
+                return this;
+            }
+
+            public MobScalingSettings build() {
+                return new MobScalingSettings(this);
+            }
+        }
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/MinorHealSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/MinorHealSkill.java
@@ -67,6 +67,6 @@ public class MinorHealSkill extends Skill {
         logger.info(casterPlayer.getName() + " used Minor Heal, restoring " + actualHeal + " health.");
 
         casterPlayer.getWorld().playSound(casterPlayer.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 0.8f, 1.5f);
-        casterProfile.setCurrentMana(casterProfile.getCurrentMana() - (long) getManaCost());
+        applyManaCost(casterProfile);
     }
 }

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/StrongStrikeSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/StrongStrikeSkill.java
@@ -100,6 +100,6 @@ public class StrongStrikeSkill extends Skill {
         casterPlayer.getWorld().playSound(casterPlayer.getLocation(), Sound.ENTITY_PLAYER_ATTACK_STRONG, 1.0f, 1.0f);
         livingTarget.getWorld().playSound(livingTarget.getLocation(), Sound.ENTITY_GENERIC_HURT, 1.0f, 1.0f);
 
-        casterProfile.setCurrentMana(casterProfile.getCurrentMana() - (long) getManaCost());
+        applyManaCost(casterProfile);
     }
 }

--- a/src/main/java/com/x1f4r/mmocraft/playerdata/runtime/PlayerRuntimeAttributeListener.java
+++ b/src/main/java/com/x1f4r/mmocraft/playerdata/runtime/PlayerRuntimeAttributeListener.java
@@ -1,0 +1,42 @@
+package com.x1f4r.mmocraft.playerdata.runtime;
+
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+
+import java.util.Objects;
+
+/**
+ * Triggers immediate synchronisation of player runtime attributes on key lifecycle events.
+ */
+public class PlayerRuntimeAttributeListener implements Listener {
+
+    private final PlayerRuntimeAttributeService runtimeAttributeService;
+    private final LoggingUtil logger;
+
+    public PlayerRuntimeAttributeListener(PlayerRuntimeAttributeService runtimeAttributeService, LoggingUtil logger) {
+        this.runtimeAttributeService = Objects.requireNonNull(runtimeAttributeService, "runtimeAttributeService");
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        runtimeAttributeService.syncPlayer(event.getPlayer());
+        logger.finer("Applied runtime attributes on join for " + event.getPlayer().getName());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerRespawn(PlayerRespawnEvent event) {
+        runtimeAttributeService.syncPlayer(event.getPlayer());
+        logger.finer("Applied runtime attributes on respawn for " + event.getPlayer().getName());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        runtimeAttributeService.clearCache(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/playerdata/runtime/PlayerRuntimeAttributeService.java
+++ b/src/main/java/com/x1f4r/mmocraft/playerdata/runtime/PlayerRuntimeAttributeService.java
@@ -1,0 +1,240 @@
+package com.x1f4r.mmocraft.playerdata.runtime;
+
+import com.x1f4r.mmocraft.config.gameplay.RuntimeStatConfig;
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Synchronises calculated player stats with live Bukkit entity attributes.
+ * This service is responsible for translating profile values such as SPEED,
+ * ATTACK_SPEED and MINING_SPEED into the corresponding runtime effects.
+ */
+public class PlayerRuntimeAttributeService {
+
+    private final PlayerDataService playerDataService;
+    private volatile RuntimeStatConfig runtimeStatConfig;
+    private final LoggingUtil logger;
+    private final Map<UUID, PlayerAttributeSnapshot> lastAppliedSnapshots = new ConcurrentHashMap<>();
+    private final HasteEffectApplier hasteEffectApplier;
+    private final AttributeResolver attributeResolver;
+
+    public PlayerRuntimeAttributeService(PlayerDataService playerDataService,
+                                         RuntimeStatConfig runtimeStatConfig,
+                                         LoggingUtil logger) {
+        this(playerDataService, runtimeStatConfig, logger, new BukkitHasteEffectApplier(logger), new BukkitAttributeResolver());
+    }
+
+    public PlayerRuntimeAttributeService(PlayerDataService playerDataService,
+                                         RuntimeStatConfig runtimeStatConfig,
+                                         LoggingUtil logger,
+                                         HasteEffectApplier hasteEffectApplier) {
+        this(playerDataService, runtimeStatConfig, logger, hasteEffectApplier, new BukkitAttributeResolver());
+    }
+
+    public PlayerRuntimeAttributeService(PlayerDataService playerDataService,
+                                         RuntimeStatConfig runtimeStatConfig,
+                                         LoggingUtil logger,
+                                         HasteEffectApplier hasteEffectApplier,
+                                         AttributeResolver attributeResolver) {
+        this.playerDataService = Objects.requireNonNull(playerDataService, "playerDataService");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.hasteEffectApplier = Objects.requireNonNull(hasteEffectApplier, "hasteEffectApplier");
+        this.attributeResolver = Objects.requireNonNull(attributeResolver, "attributeResolver");
+        updateRuntimeConfig(runtimeStatConfig);
+    }
+
+    /**
+     * Updates the runtime stat configuration used for subsequent synchronisation calls.
+     *
+     * @param runtimeStatConfig the new runtime configuration to apply.
+     */
+    public void updateRuntimeConfig(RuntimeStatConfig runtimeStatConfig) {
+        this.runtimeStatConfig = Objects.requireNonNull(runtimeStatConfig, "runtimeStatConfig");
+    }
+
+    /**
+     * Applies attribute updates to all currently online players.
+     */
+    public void updateAllPlayers() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            try {
+                syncPlayer(player);
+            } catch (Exception ex) {
+                logger.severe("Failed to apply runtime attributes for " + player.getName() + ": " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    /**
+     * Ensures the provided player's live attributes match their {@link PlayerProfile} values.
+     *
+     * @param player Bukkit player to update.
+     */
+    public void syncPlayer(Player player) {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+        PlayerProfile profile = playerDataService.getPlayerProfile(player.getUniqueId());
+        if (profile == null) {
+            return;
+        }
+        PlayerAttributeSnapshot desired = computeSnapshot(player, profile);
+        PlayerAttributeSnapshot previous = lastAppliedSnapshots.get(player.getUniqueId());
+        applySnapshot(player, profile, desired, previous);
+        lastAppliedSnapshots.put(player.getUniqueId(), desired);
+    }
+
+    /**
+     * Clears cached attribute information for a player, e.g. on quit.
+     */
+    public void clearCache(UUID playerId) {
+        if (playerId != null) {
+            lastAppliedSnapshots.remove(playerId);
+        }
+    }
+
+    private PlayerAttributeSnapshot computeSnapshot(Player player, PlayerProfile profile) {
+        RuntimeStatConfig runtimeConfig = Objects.requireNonNull(this.runtimeStatConfig, "runtimeStatConfig");
+        RuntimeStatConfig.MovementSettings movement = runtimeConfig.getMovementSettings();
+        RuntimeStatConfig.CombatSettings combat = runtimeConfig.getCombatSettings();
+        RuntimeStatConfig.GatheringSettings gathering = runtimeConfig.getGatheringSettings();
+
+        double maxHealth = profile.getMaxHealth();
+        double walkSpeedStat = profile.getStatValue(Stat.SPEED);
+        double walkSpeedBaseline = movement.getSpeedBaseline() <= 0 ? 100.0 : movement.getSpeedBaseline();
+        double scaledWalkSpeed = movement.getBaseWalkSpeed() * (walkSpeedStat / walkSpeedBaseline);
+        double walkSpeed = clamp(movement.getMinWalkSpeed(), movement.getMaxWalkSpeed(), scaledWalkSpeed);
+
+        double attackSpeedStat = profile.getStatValue(Stat.ATTACK_SPEED);
+        double attackSpeed = combat.getBaseAttackSpeed() + (attackSpeedStat * combat.getAttackSpeedPerPoint());
+        attackSpeed = Math.min(attackSpeed, combat.getMaxAttackSpeed());
+
+        double miningSpeed = profile.getStatValue(Stat.MINING_SPEED);
+        double hastePerTier = gathering.getMiningSpeedHastePerTier();
+        int hasteTier = hastePerTier <= 0 ? 0 : (int) Math.floor(miningSpeed / hastePerTier);
+        hasteTier = Math.min(hasteTier, gathering.getMiningSpeedMaxHasteTier());
+        int hasteAmplifier = hasteTier > 0 ? hasteTier - 1 : -1;
+
+        double targetHealth = Math.min(profile.getCurrentHealth(), maxHealth);
+
+        return new PlayerAttributeSnapshot(maxHealth, walkSpeed, attackSpeed, hasteAmplifier, targetHealth);
+    }
+
+    private void applySnapshot(Player player, PlayerProfile profile,
+                               PlayerAttributeSnapshot desired, PlayerAttributeSnapshot previous) {
+        if (previous == null || desired.maxHealth != previous.maxHealth) {
+            AttributeInstance maxHealthAttribute = attributeResolver.getMaxHealth(player);
+            if (maxHealthAttribute != null) {
+                maxHealthAttribute.setBaseValue(Math.max(1.0, desired.maxHealth));
+            }
+        }
+
+        if (previous == null || desired.walkSpeed != previous.walkSpeed) {
+            player.setWalkSpeed((float) desired.walkSpeed);
+        }
+
+        if (previous == null || desired.attackSpeed != previous.attackSpeed) {
+            AttributeInstance attackSpeedAttribute = attributeResolver.getAttackSpeed(player);
+            if (attackSpeedAttribute != null) {
+                attackSpeedAttribute.setBaseValue(Math.max(0.1, desired.attackSpeed));
+            }
+        }
+
+        int previousHaste = previous != null ? previous.hasteAmplifier : -1;
+        if (desired.hasteAmplifier >= 0 || previousHaste >= 0) {
+            hasteEffectApplier.apply(player, desired.hasteAmplifier, previousHaste);
+        }
+
+        double clampedHealth = clamp(0.0, desired.maxHealth, desired.targetHealth);
+        if (player.getHealth() != clampedHealth) {
+            player.setHealth(clampedHealth);
+        }
+        profile.setCurrentHealth((long) Math.round(clampedHealth));
+    }
+
+    private static double clamp(double min, double max, double value) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    @FunctionalInterface
+    public interface HasteEffectApplier {
+        void apply(Player player, int desiredAmplifier, int previousAmplifier);
+    }
+
+    private static final class BukkitHasteEffectApplier implements HasteEffectApplier {
+        private final LoggingUtil logger;
+        private final AtomicBoolean hasteWarningLogged = new AtomicBoolean(false);
+
+        private BukkitHasteEffectApplier(LoggingUtil logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public void apply(Player player, int desiredAmplifier, int previousAmplifier) {
+            PotionEffectType hasteType = resolveHasteEffectType();
+            if (hasteType == null || desiredAmplifier < 0) {
+                return;
+            }
+            PotionEffect current = player.getPotionEffect(hasteType);
+            boolean needsUpdate = current == null
+                    || current.getAmplifier() != desiredAmplifier
+                    || current.getDuration() <= 20;
+            if (needsUpdate) {
+                player.addPotionEffect(new PotionEffect(hasteType, 60, desiredAmplifier, false, false, false));
+            }
+        }
+
+        private PotionEffectType resolveHasteEffectType() {
+            try {
+                return PotionEffectType.HASTE;
+            } catch (ExceptionInInitializerError | NoClassDefFoundError | IllegalStateException | IllegalArgumentException ex) {
+                if (!hasteWarningLogged.getAndSet(true) && logger != null) {
+                    logger.warning("Unable to resolve HASTE potion effect; mining haste bonuses will be skipped: " + ex.getMessage());
+                }
+                return null;
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface AttributeResolver {
+        AttributeInstance getMaxHealth(Player player);
+
+        default AttributeInstance getAttackSpeed(Player player) {
+            return null;
+        }
+    }
+
+    private static final class BukkitAttributeResolver implements AttributeResolver {
+        @Override
+        public AttributeInstance getMaxHealth(Player player) {
+            return player.getAttribute(Attribute.MAX_HEALTH);
+        }
+
+        @Override
+        public AttributeInstance getAttackSpeed(Player player) {
+            return player.getAttribute(Attribute.ATTACK_SPEED);
+        }
+    }
+
+    private record PlayerAttributeSnapshot(double maxHealth,
+                                           double walkSpeed,
+                                           double attackSpeed,
+                                           int hasteAmplifier,
+                                           double targetHealth) {
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/statuseffect/model/ActiveStatusEffect.java
+++ b/src/main/java/com/x1f4r/mmocraft/statuseffect/model/ActiveStatusEffect.java
@@ -13,6 +13,7 @@ public class ActiveStatusEffect {
 
     private final StatusEffect statusEffect;
     private final UUID targetId; // UUID of the LivingEntity this effect is on
+    private final UUID instanceId;
     private final long applicationTimeMillis;
     private long expirationTimeMillis; // System.currentTimeMillis() + duration. Long.MAX_VALUE if permanent.
     private long nextTickTimeMillis;   // For effects with tickIntervalSeconds > 0
@@ -27,6 +28,7 @@ public class ActiveStatusEffect {
     public ActiveStatusEffect(StatusEffect statusEffect, UUID targetId) {
         this.statusEffect = Objects.requireNonNull(statusEffect, "StatusEffect cannot be null.");
         this.targetId = Objects.requireNonNull(targetId, "Target UUID cannot be null.");
+        this.instanceId = UUID.randomUUID();
         this.applicationTimeMillis = System.currentTimeMillis();
 
         if (statusEffect.isPermanent()) {
@@ -46,6 +48,7 @@ public class ActiveStatusEffect {
     // Getters
     public StatusEffect getStatusEffect() { return statusEffect; }
     public UUID getTargetId() { return targetId; }
+    public UUID getInstanceId() { return instanceId; }
     public long getApplicationTimeMillis() { return applicationTimeMillis; }
     public long getExpirationTimeMillis() { return expirationTimeMillis; }
     public long getNextTickTimeMillis() { return nextTickTimeMillis; }

--- a/src/main/java/com/x1f4r/mmocraft/world/resourcegathering/listeners/ResourceNodeInteractionListener.java
+++ b/src/main/java/com/x1f4r/mmocraft/world/resourcegathering/listeners/ResourceNodeInteractionListener.java
@@ -1,9 +1,13 @@
 package com.x1f4r.mmocraft.world.resourcegathering.listeners;
 
 import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.config.gameplay.GameplayConfigService;
+import com.x1f4r.mmocraft.config.gameplay.RuntimeStatConfig;
 import com.x1f4r.mmocraft.item.service.CustomItemRegistry; // For potential custom tool interactions
 import com.x1f4r.mmocraft.loot.service.LootService;
 import com.x1f4r.mmocraft.playerdata.PlayerDataService; // For player stats/skills affecting gathering
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
 import com.x1f4r.mmocraft.util.LoggingUtil;
 import com.x1f4r.mmocraft.util.StringUtil;
 import com.x1f4r.mmocraft.world.resourcegathering.model.ActiveResourceNode;
@@ -20,7 +24,13 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class ResourceNodeInteractionListener implements Listener {
 
@@ -30,18 +40,21 @@ public class ResourceNodeInteractionListener implements Listener {
     private final LootService lootService;
     private final CustomItemRegistry customItemRegistry; // Currently unused, for future expansion
     private final PlayerDataService playerDataService;   // Currently unused, for future expansion
+    private final GameplayConfigService gameplayConfigService;
     private final LoggingUtil logger;
+    private final Map<UUID, Long> gatherCooldowns = new ConcurrentHashMap<>();
 
     public ResourceNodeInteractionListener(MMOCraftPlugin plugin, ActiveNodeManager activeNodeManager,
                                            ResourceNodeRegistryService nodeRegistryService, LootService lootService,
                                            CustomItemRegistry customItemRegistry, PlayerDataService playerDataService,
-                                           LoggingUtil logger) {
+                                           GameplayConfigService gameplayConfigService, LoggingUtil logger) {
         this.plugin = plugin;
         this.activeNodeManager = activeNodeManager;
         this.nodeRegistryService = nodeRegistryService;
         this.lootService = lootService;
         this.customItemRegistry = customItemRegistry;
         this.playerDataService = playerDataService;
+        this.gameplayConfigService = gameplayConfigService;
         this.logger = logger;
     }
 
@@ -62,7 +75,6 @@ public class ResourceNodeInteractionListener implements Listener {
         // Set drop to 0 to ensure no vanilla drops if not cancelled fully or by other plugins.
         event.setDropItems(false);
 
-
         ActiveResourceNode activeNode = activeNodeOpt.get();
 
         if (activeNode.isDepleted()) {
@@ -78,6 +90,23 @@ public class ResourceNodeInteractionListener implements Listener {
         }
 
         ResourceNodeType nodeType = nodeTypeOpt.get();
+
+        PlayerProfile profile = playerDataService.getPlayerProfile(player.getUniqueId());
+        RuntimeStatConfig.GatheringSettings gatheringSettings = gameplayConfigService.getRuntimeStatConfig().getGatheringSettings();
+        double miningSpeed = profile != null ? profile.getStatValue(Stat.MINING_SPEED) : 0.0;
+        double divisor = gatheringSettings.getMiningSpeedDelayDivisor();
+        double speedFactor = divisor <= 0 ? 0.0 : (miningSpeed / divisor);
+        double effectiveDelaySeconds = nodeType.getBreakTimeSeconds() / Math.max(1.0, 1.0 + speedFactor);
+        effectiveDelaySeconds = Math.max(gatheringSettings.getMinimumGatherDelaySeconds(), effectiveDelaySeconds);
+
+        long now = System.currentTimeMillis();
+        long cooldownUntil = gatherCooldowns.getOrDefault(player.getUniqueId(), 0L);
+        if (cooldownUntil > now) {
+            double remainingSeconds = (cooldownUntil - now) / 1000.0;
+            player.sendActionBar(StringUtil.colorize(String.format("&cGathering... %.1fs remaining", remainingSeconds)));
+            return;
+        }
+        gatherCooldowns.put(player.getUniqueId(), now + (long) (effectiveDelaySeconds * 1000));
 
         // 1. Check Tool Requirements
         if (!nodeType.getRequiredToolTypes().isEmpty()) {
@@ -97,11 +126,14 @@ public class ResourceNodeInteractionListener implements Listener {
 
         // 3. Distribute Loot
         lootService.getLootTableById(nodeType.getLootTableId()).ifPresentOrElse(lootTable -> {
-            // Generate loot and give it to the player or drop it at the node's location.
-            // For simplicity, let's drop at player's location for now.
+            double fortuneMultiplier = computeFortuneMultiplier(profile, nodeType, gatheringSettings);
             lootTable.generateLoot(customItemRegistry, plugin).forEach(itemStack -> {
-                if (itemStack != null && itemStack.getAmount() > 0) {
-                    player.getWorld().dropItemNaturally(player.getLocation(), itemStack);
+                if (itemStack == null || itemStack.getAmount() <= 0) {
+                    return;
+                }
+                ItemStack adjusted = applyFortune(itemStack, fortuneMultiplier);
+                if (adjusted.getAmount() > 0) {
+                    player.getWorld().dropItemNaturally(player.getLocation(), adjusted);
                 }
             });
             player.sendMessage(StringUtil.colorize("&aYou successfully gathered resources from &e" + nodeType.getEffectiveName() + "&a!"));
@@ -117,4 +149,46 @@ public class ResourceNodeInteractionListener implements Listener {
              activeNodeManager.depleteNode(activeNode);
         });
     }
+
+    private double computeFortuneMultiplier(PlayerProfile profile, ResourceNodeType nodeType, RuntimeStatConfig.GatheringSettings settings) {
+        Stat fortuneStat = resolveFortuneStat(nodeType);
+        double perPoint = settings.getFortunePerPoint(fortuneStat);
+        double statValue = profile != null ? profile.getStatValue(fortuneStat) : 0.0;
+        return Math.max(1.0, 1.0 + (statValue * perPoint));
+    }
+
+    private Stat resolveFortuneStat(ResourceNodeType nodeType) {
+        Material material = nodeType.getDisplayMaterial();
+        if (material == null) {
+            return Stat.MINING_FORTUNE;
+        }
+        String name = material.name();
+        if (FARMING_MATERIALS.contains(material) || name.contains("WHEAT") || name.contains("CARROT") || name.contains("POTATO") || name.contains("BEETROOT")) {
+            return Stat.FARMING_FORTUNE;
+        }
+        if (name.contains("LOG") || name.contains("STEM") || name.contains("HYPHAE")) {
+            return Stat.FORAGING_FORTUNE;
+        }
+        if (name.contains("FISH") || name.contains("COD") || name.contains("SALMON") || name.contains("TROPICAL")) {
+            return Stat.FISHING_FORTUNE;
+        }
+        return Stat.MINING_FORTUNE;
+    }
+
+    private ItemStack applyFortune(ItemStack original, double multiplier) {
+        ItemStack clone = original.clone();
+        double scaledAmount = clone.getAmount() * multiplier;
+        int guaranteed = (int) Math.floor(scaledAmount);
+        double fractional = scaledAmount - guaranteed;
+        int bonus = ThreadLocalRandom.current().nextDouble() < fractional ? 1 : 0;
+        int finalAmount = Math.max(0, guaranteed + bonus);
+        clone.setAmount(finalAmount);
+        return clone;
+    }
+
+    private static final Set<Material> FARMING_MATERIALS = EnumSet.of(
+            Material.WHEAT, Material.CARROTS, Material.POTATOES, Material.BEETROOTS,
+            Material.NETHER_WART, Material.SWEET_BERRY_BUSH, Material.BAMBOO,
+            Material.MELON, Material.PUMPKIN, Material.KELP
+    );
 }

--- a/src/main/java/com/x1f4r/mmocraft/world/zone/runtime/ZoneStatApplier.java
+++ b/src/main/java/com/x1f4r/mmocraft/world/zone/runtime/ZoneStatApplier.java
@@ -1,0 +1,129 @@
+package com.x1f4r.mmocraft.world.zone.runtime;
+
+import com.x1f4r.mmocraft.eventbus.EventBusService;
+import com.x1f4r.mmocraft.eventbus.EventHandler;
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.playerdata.runtime.PlayerRuntimeAttributeService;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import com.x1f4r.mmocraft.world.zone.event.PlayerEnterZoneEvent;
+import com.x1f4r.mmocraft.world.zone.event.PlayerLeaveZoneEvent;
+import com.x1f4r.mmocraft.world.zone.model.Zone;
+import com.x1f4r.mmocraft.world.zone.service.ZoneManager;
+import org.bukkit.entity.Player;
+
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Applies zone-defined stat bonuses and penalties to player profiles via temporary modifiers.
+ */
+public class ZoneStatApplier {
+
+    private static final String ZONE_SOURCE_PREFIX = "zone:";
+
+    private final ZoneManager zoneManager;
+    private final PlayerDataService playerDataService;
+    private final EventBusService eventBusService;
+    private final PlayerRuntimeAttributeService runtimeAttributeService;
+    private final LoggingUtil logger;
+
+    private final EventHandler<PlayerEnterZoneEvent> enterHandler = this::handleEnter;
+    private final EventHandler<PlayerLeaveZoneEvent> leaveHandler = this::handleLeave;
+
+    public ZoneStatApplier(ZoneManager zoneManager,
+                           PlayerDataService playerDataService,
+                           EventBusService eventBusService,
+                           PlayerRuntimeAttributeService runtimeAttributeService,
+                           LoggingUtil logger) {
+        this.zoneManager = Objects.requireNonNull(zoneManager, "zoneManager");
+        this.playerDataService = Objects.requireNonNull(playerDataService, "playerDataService");
+        this.eventBusService = Objects.requireNonNull(eventBusService, "eventBusService");
+        this.runtimeAttributeService = Objects.requireNonNull(runtimeAttributeService, "runtimeAttributeService");
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    public void register() {
+        eventBusService.register(PlayerEnterZoneEvent.class, enterHandler);
+        eventBusService.register(PlayerLeaveZoneEvent.class, leaveHandler);
+    }
+
+    public void shutdown() {
+        eventBusService.unregister(PlayerEnterZoneEvent.class, enterHandler);
+        eventBusService.unregister(PlayerLeaveZoneEvent.class, leaveHandler);
+    }
+
+    private void handleEnter(PlayerEnterZoneEvent event) {
+        applyZoneModifiers(event.getPlayer(), event.getZone());
+    }
+
+    private void handleLeave(PlayerLeaveZoneEvent event) {
+        Player player = event.getPlayer();
+        PlayerProfile profile = playerDataService.getPlayerProfile(player.getUniqueId());
+        if (profile == null) {
+            return;
+        }
+        profile.clearTemporaryStatModifiers(buildSourceKey(event.getZone().getZoneId()));
+        runtimeAttributeService.syncPlayer(player);
+    }
+
+    private void applyZoneModifiers(Player player, Zone zone) {
+        PlayerProfile profile = playerDataService.getPlayerProfile(player.getUniqueId());
+        if (profile == null) {
+            return;
+        }
+        Map<Stat, Double> modifiers = extractModifiers(zone);
+        String sourceKey = buildSourceKey(zone.getZoneId());
+        if (modifiers.isEmpty()) {
+            profile.clearTemporaryStatModifiers(sourceKey);
+        } else {
+            profile.setTemporaryStatModifiers(sourceKey, modifiers);
+        }
+        runtimeAttributeService.syncPlayer(player);
+    }
+
+    private Map<Stat, Double> extractModifiers(Zone zone) {
+        Map<Stat, Double> modifiers = new EnumMap<>(Stat.class);
+        zone.getProperties().forEach((key, value) -> {
+            if (key == null) {
+                return;
+            }
+            String lowered = key.toLowerCase(Locale.ROOT);
+            if (!lowered.startsWith("stat.")) {
+                return;
+            }
+            String statName = lowered.substring("stat.".length()).replace('-', '_');
+            try {
+                Stat stat = Stat.valueOf(statName.toUpperCase(Locale.ROOT));
+                Double numericValue = toDouble(value);
+                if (numericValue != null && numericValue != 0.0) {
+                    modifiers.put(stat, numericValue);
+                }
+            } catch (IllegalArgumentException ex) {
+                logger.warning("Zone " + zone.getZoneId() + " references unknown stat modifier '" + statName + "'.");
+            }
+        });
+        return modifiers;
+    }
+
+    private Double toDouble(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String str) {
+            try {
+                return Double.parseDouble(str);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private String buildSourceKey(String zoneId) {
+        return ZONE_SOURCE_PREFIX + zoneId.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/resources/config/stats.yml
+++ b/src/main/resources/config/stats.yml
@@ -117,3 +117,46 @@ combat:
   max-damage-reduction: 0.9
   max-evasion-chance: 0.6
 
+runtime:
+  movement:
+    base-walk-speed: 0.2
+    max-walk-speed: 0.6
+    min-walk-speed: 0.05
+    speed-baseline: 100.0
+  combat:
+    base-attack-speed: 4.0
+    attack-speed-per-point: 0.02
+    max-attack-speed: 8.0
+    strength-physical-scaling: 0.5
+    intelligence-magical-scaling: 0.7
+    ability-power-percent-per-point: 1.0
+    ferocity-per-extra-hit: 100.0
+    ferocity-max-extra-hits: 4
+    mob-defense-reduction-factor: 0.04
+  ability:
+    cooldown-reduction-per-attack-speed-point: 0.002
+    cooldown-reduction-per-intelligence-point: 0.0
+    minimum-cooldown-seconds: 0.2
+    mana-cost-reduction-per-intelligence-point: 0.001
+    mana-cost-reduction-per-ability-power-point: 0.001
+    minimum-mana-cost-multiplier: 0.2
+    minimum-mana-cost: 1.0
+  gathering:
+    base-gather-delay-seconds: 1.0
+    minimum-gather-delay-seconds: 0.25
+    mining-speed-delay-divisor: 100.0
+    mining-speed-haste-per-tier: 80.0
+    mining-speed-max-haste-tier: 4
+    fortune-per-point:
+      mining_fortune: 0.002
+      farming_fortune: 0.002
+      foraging_fortune: 0.002
+      fishing_fortune: 0.0015
+  mobs:
+    health-per-level-percent: 0.05
+    damage-per-level-percent: 0.03
+    defense-per-level: 0.5
+    max-health-multiplier: 5.0
+    max-damage-multiplier: 5.0
+    max-defense-bonus: 200.0
+

--- a/src/test/java/com/x1f4r/mmocraft/combat/service/BasicDamageCalculationServiceTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/combat/service/BasicDamageCalculationServiceTest.java
@@ -1,0 +1,154 @@
+package com.x1f4r.mmocraft.combat.service;
+
+import com.x1f4r.mmocraft.combat.model.DamageInstance;
+import com.x1f4r.mmocraft.combat.model.DamageType;
+import com.x1f4r.mmocraft.config.gameplay.GameplayConfigService;
+import com.x1f4r.mmocraft.config.gameplay.RuntimeStatConfig;
+import com.x1f4r.mmocraft.config.gameplay.RuntimeStatConfig.MobScalingSettings;
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class BasicDamageCalculationServiceTest {
+
+    @Test
+    void calculatesFerocityExtraHitsAgainstMobs() {
+        PlayerDataService playerDataService = mock(PlayerDataService.class);
+        LoggingUtil loggingUtil = mock(LoggingUtil.class);
+        MobStatProvider mobStatProvider = mock(MobStatProvider.class);
+        GameplayConfigService gameplayConfigService = mock(GameplayConfigService.class);
+
+        RuntimeStatConfig runtimeConfig = RuntimeStatConfig.defaults();
+        when(gameplayConfigService.getRuntimeStatConfig()).thenReturn(runtimeConfig);
+
+        BasicDamageCalculationService service = new BasicDamageCalculationService(playerDataService, loggingUtil, mobStatProvider, gameplayConfigService);
+
+        Player attacker = mock(Player.class);
+        UUID attackerId = UUID.randomUUID();
+        when(attacker.getUniqueId()).thenReturn(attackerId);
+        when(attacker.getName()).thenReturn("Attacker");
+
+        LivingEntity victim = mock(LivingEntity.class);
+        UUID victimId = UUID.randomUUID();
+        when(victim.getUniqueId()).thenReturn(victimId);
+        when(victim.getType()).thenReturn(EntityType.ZOMBIE);
+        when(victim.hasMetadata(anyString())).thenReturn(false);
+
+        PlayerProfile attackerProfile = mock(PlayerProfile.class);
+        when(attackerProfile.getStatValue(Stat.STRENGTH)).thenReturn(50.0);
+        when(attackerProfile.getStatValue(Stat.FEROCITY)).thenReturn(200.0);
+        when(attackerProfile.getCriticalHitChance()).thenReturn(0.0);
+        when(attackerProfile.getCriticalDamageBonus()).thenReturn(2.0);
+        when(attackerProfile.getLevel()).thenReturn(1);
+        when(playerDataService.getPlayerProfile(attackerId)).thenReturn(attackerProfile);
+        when(playerDataService.getPlayerProfile(victimId)).thenReturn(null);
+
+        when(mobStatProvider.getBaseDefense(EntityType.ZOMBIE)).thenReturn(0.0);
+
+        DamageInstance instance = service.calculateDamage(attacker, victim, 100.0, DamageType.PHYSICAL);
+
+        assertEquals(375.0, instance.finalDamage(), 1e-6);
+        assertEquals(125.0, instance.baseDamage(), 1e-6);
+        assertTrue(instance.mitigationDetails().contains("Ferocity:2x"));
+        assertFalse(instance.criticalHit());
+        assertFalse(instance.evaded());
+    }
+
+    @Test
+    void appliesVictimDamageReduction() {
+        PlayerDataService playerDataService = mock(PlayerDataService.class);
+        LoggingUtil loggingUtil = mock(LoggingUtil.class);
+        MobStatProvider mobStatProvider = mock(MobStatProvider.class);
+        GameplayConfigService gameplayConfigService = mock(GameplayConfigService.class);
+
+        RuntimeStatConfig runtimeConfig = RuntimeStatConfig.defaults();
+        when(gameplayConfigService.getRuntimeStatConfig()).thenReturn(runtimeConfig);
+
+        BasicDamageCalculationService service = new BasicDamageCalculationService(playerDataService, loggingUtil, mobStatProvider, gameplayConfigService);
+
+        Player attacker = mock(Player.class);
+        UUID attackerId = UUID.randomUUID();
+        when(attacker.getUniqueId()).thenReturn(attackerId);
+        when(attacker.getName()).thenReturn("Attacker");
+
+        Player victim = mock(Player.class);
+        UUID victimId = UUID.randomUUID();
+        when(victim.getUniqueId()).thenReturn(victimId);
+        when(victim.getName()).thenReturn("Victim");
+
+        PlayerProfile attackerProfile = mock(PlayerProfile.class);
+        when(attackerProfile.getStatValue(Stat.STRENGTH)).thenReturn(50.0);
+        when(attackerProfile.getStatValue(Stat.FEROCITY)).thenReturn(0.0);
+        when(attackerProfile.getCriticalHitChance()).thenReturn(0.0);
+        when(attackerProfile.getCriticalDamageBonus()).thenReturn(2.0);
+        when(playerDataService.getPlayerProfile(attackerId)).thenReturn(attackerProfile);
+
+        PlayerProfile victimProfile = mock(PlayerProfile.class);
+        when(victimProfile.getPhysicalDamageReduction()).thenReturn(0.4);
+        when(victimProfile.getMagicDamageReduction()).thenReturn(0.4);
+        when(victimProfile.getEvasionChance()).thenReturn(0.0);
+        when(playerDataService.getPlayerProfile(victimId)).thenReturn(victimProfile);
+
+        DamageInstance instance = service.calculateDamage(attacker, victim, 100.0, DamageType.PHYSICAL);
+
+        assertEquals(75.0, instance.finalDamage(), 1e-6);
+        assertTrue(instance.mitigationDetails().contains("P.Reduc"));
+    }
+
+    @Test
+    void scalesMobDamageAgainstPlayerLevel() {
+        PlayerDataService playerDataService = mock(PlayerDataService.class);
+        LoggingUtil loggingUtil = mock(LoggingUtil.class);
+        MobStatProvider mobStatProvider = mock(MobStatProvider.class);
+        GameplayConfigService gameplayConfigService = mock(GameplayConfigService.class);
+
+        RuntimeStatConfig runtimeConfig = RuntimeStatConfig.defaults().toBuilder()
+                .mobScalingSettings(MobScalingSettings.builder()
+                        .healthPerLevelPercent(0.05)
+                        .damagePerLevelPercent(0.05)
+                        .defensePerLevel(0.5)
+                        .maxHealthMultiplier(5.0)
+                        .maxDamageMultiplier(3.0)
+                        .maxDefenseBonus(200.0))
+                .build();
+        when(gameplayConfigService.getRuntimeStatConfig()).thenReturn(runtimeConfig);
+
+        BasicDamageCalculationService service = new BasicDamageCalculationService(playerDataService, loggingUtil, mobStatProvider, gameplayConfigService);
+
+        LivingEntity mob = mock(LivingEntity.class);
+        UUID mobId = UUID.randomUUID();
+        when(mob.getUniqueId()).thenReturn(mobId);
+        when(mob.getType()).thenReturn(EntityType.ZOMBIE);
+        when(mob.getName()).thenReturn("Zombie");
+
+        Player victim = mock(Player.class);
+        UUID victimId = UUID.randomUUID();
+        when(victim.getUniqueId()).thenReturn(victimId);
+        when(victim.getName()).thenReturn("Victim");
+
+        PlayerProfile victimProfile = mock(PlayerProfile.class);
+        when(victimProfile.getLevel()).thenReturn(10);
+        when(victimProfile.getEvasionChance()).thenReturn(0.0);
+        when(victimProfile.getPhysicalDamageReduction()).thenReturn(0.0);
+        when(victimProfile.getMagicDamageReduction()).thenReturn(0.0);
+
+        when(playerDataService.getPlayerProfile(mobId)).thenReturn(null);
+        when(playerDataService.getPlayerProfile(victimId)).thenReturn(victimProfile);
+
+        DamageInstance instance = service.calculateDamage(mob, victim, 100.0, DamageType.PHYSICAL);
+
+        assertEquals(145.0, instance.finalDamage(), 1e-6);
+        assertTrue(instance.mitigationDetails().contains("MobScale:+45%"));
+    }
+}

--- a/src/test/java/com/x1f4r/mmocraft/command/commands/admin/MMOCAdminRootCommandTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/command/commands/admin/MMOCAdminRootCommandTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,7 +22,7 @@ class MMOCAdminRootCommandTest {
 
     @BeforeEach
     void setUp() {
-        when(sender.hasPermission("mmocraft.admin")).thenReturn(true);
+        when(sender.hasPermission(anyString())).thenReturn(true);
     }
 
     @Test
@@ -32,6 +33,8 @@ class MMOCAdminRootCommandTest {
 
         assertTrue(handled);
         verify(plugin).reloadPluginConfig();
-        verify(sender).sendMessage(contains("configuration reloaded"));
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sender).sendMessage(messageCaptor.capture());
+        assertTrue(messageCaptor.getValue().contains("configuration reloaded"));
     }
 }

--- a/src/test/java/com/x1f4r/mmocraft/playerdata/runtime/PlayerRuntimeAttributeServiceTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/playerdata/runtime/PlayerRuntimeAttributeServiceTest.java
@@ -1,0 +1,159 @@
+package com.x1f4r.mmocraft.playerdata.runtime;
+
+import com.x1f4r.mmocraft.config.gameplay.RuntimeStatConfig;
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class PlayerRuntimeAttributeServiceTest {
+
+    @Test
+    void syncPlayerAppliesAttributesAndCachesSnapshot() {
+        PlayerDataService playerDataService = mock(PlayerDataService.class);
+        LoggingUtil loggingUtil = mock(LoggingUtil.class);
+        RuntimeStatConfig runtimeConfig = RuntimeStatConfig.defaults();
+        TestHasteEffectApplier hasteApplier = new TestHasteEffectApplier(false);
+        AttributeInstance maxHealthAttribute = mock(AttributeInstance.class);
+        AttributeInstance attackSpeedAttribute = mock(AttributeInstance.class);
+        TestAttributeResolver attributeResolver = new TestAttributeResolver(maxHealthAttribute, attackSpeedAttribute);
+        PlayerRuntimeAttributeService service = new PlayerRuntimeAttributeService(playerDataService, runtimeConfig, loggingUtil, hasteApplier, attributeResolver);
+
+        UUID playerId = UUID.randomUUID();
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(playerId);
+        when(player.isOnline()).thenReturn(true);
+        when(player.getName()).thenReturn("Tester");
+        when(player.getHealth()).thenReturn(140.0, 150.0, 150.0);
+
+        PlayerProfile profile = mock(PlayerProfile.class);
+        when(profile.getMaxHealth()).thenReturn(200L);
+        when(profile.getCurrentHealth()).thenReturn(150L);
+        when(profile.getStatValue(Stat.SPEED)).thenReturn(150.0);
+        when(profile.getStatValue(Stat.ATTACK_SPEED)).thenReturn(50.0);
+        when(profile.getStatValue(Stat.MINING_SPEED)).thenReturn(0.0);
+        when(playerDataService.getPlayerProfile(playerId)).thenReturn(profile);
+
+        service.syncPlayer(player);
+        service.syncPlayer(player);
+        service.clearCache(playerId);
+        service.syncPlayer(player);
+
+        verify(maxHealthAttribute, times(2)).setBaseValue(200.0);
+        verify(player, times(2)).setWalkSpeed(0.3f);
+        verify(attackSpeedAttribute, times(2)).setBaseValue(5.0);
+        verify(player, times(1)).setHealth(150.0);
+        verify(profile, times(3)).setCurrentHealth(150L);
+    }
+
+    @Test
+    void updateRuntimeConfigChangesAppliedValues() {
+        PlayerDataService playerDataService = mock(PlayerDataService.class);
+        LoggingUtil loggingUtil = mock(LoggingUtil.class);
+        RuntimeStatConfig initialConfig = RuntimeStatConfig.defaults();
+        TestHasteEffectApplier hasteApplier = new TestHasteEffectApplier(true);
+        AttributeInstance maxHealthAttribute = mock(AttributeInstance.class);
+        AttributeInstance attackSpeedAttribute = mock(AttributeInstance.class);
+        TestAttributeResolver attributeResolver = new TestAttributeResolver(maxHealthAttribute, attackSpeedAttribute);
+        PlayerRuntimeAttributeService service = new PlayerRuntimeAttributeService(playerDataService, initialConfig, loggingUtil, hasteApplier, attributeResolver);
+
+        UUID playerId = UUID.randomUUID();
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(playerId);
+        when(player.isOnline()).thenReturn(true);
+        when(player.getName()).thenReturn("Tester");
+        when(player.getHealth()).thenReturn(140.0, 150.0, 150.0);
+        PlayerProfile profile = mock(PlayerProfile.class);
+        when(profile.getMaxHealth()).thenReturn(200L);
+        when(profile.getCurrentHealth()).thenReturn(150L);
+        when(profile.getStatValue(Stat.SPEED)).thenReturn(150.0);
+        when(profile.getStatValue(Stat.ATTACK_SPEED)).thenReturn(50.0);
+        when(profile.getStatValue(Stat.MINING_SPEED)).thenReturn(160.0);
+        when(playerDataService.getPlayerProfile(playerId)).thenReturn(profile);
+
+        service.syncPlayer(player);
+
+        RuntimeStatConfig updatedConfig = initialConfig.toBuilder()
+                .movementSettings(RuntimeStatConfig.MovementSettings.builder()
+                        .baseWalkSpeed(0.4)
+                        .maxWalkSpeed(0.9)
+                        .minWalkSpeed(0.05)
+                        .speedBaseline(100.0))
+                .combatSettings(RuntimeStatConfig.CombatSettings.builder()
+                        .baseAttackSpeed(2.0)
+                        .attackSpeedPerPoint(0.05)
+                        .maxAttackSpeed(10.0)
+                        .strengthPhysicalScaling(initialConfig.getCombatSettings().getStrengthPhysicalScaling())
+                        .intelligenceMagicalScaling(initialConfig.getCombatSettings().getIntelligenceMagicalScaling())
+                        .abilityPowerPercentPerPoint(initialConfig.getCombatSettings().getAbilityPowerPercentPerPoint())
+                        .ferocityPerExtraHit(initialConfig.getCombatSettings().getFerocityPerExtraHit())
+                        .ferocityMaxExtraHits(initialConfig.getCombatSettings().getFerocityMaxExtraHits())
+                        .mobDefenseReductionFactor(initialConfig.getCombatSettings().getMobDefenseReductionFactor()))
+                .gatheringSettings(RuntimeStatConfig.GatheringSettings.builder()
+                        .baseGatherDelaySeconds(initialConfig.getGatheringSettings().getBaseGatherDelaySeconds())
+                        .minimumGatherDelaySeconds(initialConfig.getGatheringSettings().getMinimumGatherDelaySeconds())
+                        .miningSpeedDelayDivisor(initialConfig.getGatheringSettings().getMiningSpeedDelayDivisor())
+                        .miningSpeedHastePerTier(40.0)
+                        .miningSpeedMaxHasteTier(5))
+                .build();
+
+        service.updateRuntimeConfig(updatedConfig);
+        service.syncPlayer(player);
+
+        verify(player).setWalkSpeed(0.3f);
+        verify(player).setWalkSpeed(0.6f);
+        verify(attackSpeedAttribute).setBaseValue(5.0);
+        verify(attackSpeedAttribute).setBaseValue(4.5);
+        assertEquals(List.of(1, 3), hasteApplier.getRecordedAmplifiers());
+    }
+
+    private static final class TestHasteEffectApplier implements PlayerRuntimeAttributeService.HasteEffectApplier {
+        private final boolean hasteAvailable;
+        private final List<Integer> recordedAmplifiers = new java.util.ArrayList<>();
+
+        private TestHasteEffectApplier(boolean hasteAvailable) {
+            this.hasteAvailable = hasteAvailable;
+        }
+
+        @Override
+        public void apply(Player player, int desiredAmplifier, int previousAmplifier) {
+            if (!hasteAvailable || desiredAmplifier < 0) {
+                return;
+            }
+            recordedAmplifiers.add(desiredAmplifier);
+        }
+
+        private List<Integer> getRecordedAmplifiers() {
+            return recordedAmplifiers;
+        }
+    }
+
+    private static final class TestAttributeResolver implements PlayerRuntimeAttributeService.AttributeResolver {
+        private final AttributeInstance maxHealth;
+        private final AttributeInstance attackSpeed;
+
+        private TestAttributeResolver(AttributeInstance maxHealth, AttributeInstance attackSpeed) {
+            this.maxHealth = maxHealth;
+            this.attackSpeed = attackSpeed;
+        }
+
+        @Override
+        public AttributeInstance getMaxHealth(Player player) {
+            return maxHealth;
+        }
+
+        @Override
+        public AttributeInstance getAttackSpeed(Player player) {
+            return attackSpeed;
+        }
+    }
+}

--- a/src/test/java/com/x1f4r/mmocraft/skill/model/SkillAbilityScalingTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/skill/model/SkillAbilityScalingTest.java
@@ -1,0 +1,72 @@
+package com.x1f4r.mmocraft.skill.model;
+
+import com.x1f4r.mmocraft.config.gameplay.GameplayConfigService;
+import com.x1f4r.mmocraft.config.gameplay.RuntimeStatConfig;
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SkillAbilityScalingTest {
+
+    @Test
+    void abilityStatsModifyManaCostAndCooldown() {
+        MMOCraftPlugin plugin = mock(MMOCraftPlugin.class);
+        GameplayConfigService gameplayConfigService = mock(GameplayConfigService.class);
+        when(plugin.getGameplayConfigService()).thenReturn(gameplayConfigService);
+
+        RuntimeStatConfig runtimeConfig = RuntimeStatConfig.defaults().toBuilder()
+                .abilitySettings(RuntimeStatConfig.AbilitySettings.builder()
+                        .cooldownReductionPerAttackSpeedPoint(0.01)
+                        .cooldownReductionPerIntelligencePoint(0.005)
+                        .minimumCooldownSeconds(0.5)
+                        .manaCostReductionPerIntelligencePoint(0.002)
+                        .manaCostReductionPerAbilityPowerPoint(0.001)
+                        .minimumManaCostMultiplier(0.3)
+                        .minimumManaCost(2.0))
+                .build();
+        when(gameplayConfigService.getRuntimeStatConfig()).thenReturn(runtimeConfig);
+
+        TestSkill skill = new TestSkill(plugin, 100.0, 10.0);
+
+        PlayerProfile profile = mock(PlayerProfile.class);
+        when(profile.getStatValue(Stat.INTELLIGENCE)).thenReturn(100.0);
+        when(profile.getStatValue(Stat.ABILITY_POWER)).thenReturn(50.0);
+        when(profile.getStatValue(Stat.ATTACK_SPEED)).thenReturn(20.0);
+        when(profile.getCurrentMana()).thenReturn(70L, 80L);
+        when(profile.isSkillOnCooldown("test_skill")).thenReturn(false);
+
+        double effectiveManaCost = skill.getEffectiveManaCost(profile);
+        assertEquals(75.0, effectiveManaCost, 1e-6);
+        assertFalse(skill.canUse(profile));
+        assertTrue(skill.canUse(profile));
+
+        long spent = skill.applyManaCost(profile);
+        assertEquals(75L, spent);
+        verify(profile).consumeMana(75L);
+
+        double effectiveCooldown = skill.getEffectiveCooldownSeconds(profile);
+        assertEquals(3.0, effectiveCooldown, 1e-6);
+        skill.onCooldown(profile);
+        ArgumentCaptor<Double> cooldownCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(profile).setSkillCooldown(eq("test_skill"), cooldownCaptor.capture());
+        assertEquals(3.0, cooldownCaptor.getValue(), 1e-6);
+    }
+
+    private static final class TestSkill extends Skill {
+        private TestSkill(MMOCraftPlugin plugin, double manaCost, double cooldownSeconds) {
+            super(plugin, "test_skill", "Test Skill", "A skill for testing.", manaCost, cooldownSeconds, 0.0, SkillType.ACTIVE_SELF);
+        }
+
+        @Override
+        public void execute(PlayerProfile casterProfile, Entity targetEntity, Location targetLocation) {
+            // No-op for testing.
+        }
+    }
+}

--- a/src/test/java/com/x1f4r/mmocraft/world/resourcegathering/listeners/ResourceNodeInteractionListenerTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/world/resourcegathering/listeners/ResourceNodeInteractionListenerTest.java
@@ -1,0 +1,136 @@
+package com.x1f4r.mmocraft.world.resourcegathering.listeners;
+
+import com.x1f4r.mmocraft.config.gameplay.GameplayConfigService;
+import com.x1f4r.mmocraft.config.gameplay.RuntimeStatConfig;
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.item.service.CustomItemRegistry;
+import com.x1f4r.mmocraft.loot.model.LootTable;
+import com.x1f4r.mmocraft.loot.service.LootService;
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import com.x1f4r.mmocraft.world.resourcegathering.model.ActiveResourceNode;
+import com.x1f4r.mmocraft.world.resourcegathering.model.ResourceNodeType;
+import com.x1f4r.mmocraft.world.resourcegathering.service.ActiveNodeManager;
+import com.x1f4r.mmocraft.world.resourcegathering.service.ResourceNodeRegistryService;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class ResourceNodeInteractionListenerTest {
+
+    @Test
+    void dropsFortunedLootAndDepletesNode() {
+        MMOCraftPlugin plugin = mock(MMOCraftPlugin.class);
+        ActiveNodeManager activeNodeManager = mock(ActiveNodeManager.class);
+        ResourceNodeRegistryService nodeRegistryService = mock(ResourceNodeRegistryService.class);
+        LootService lootService = mock(LootService.class);
+        CustomItemRegistry customItemRegistry = mock(CustomItemRegistry.class);
+        PlayerDataService playerDataService = mock(PlayerDataService.class);
+        GameplayConfigService gameplayConfigService = mock(GameplayConfigService.class);
+        LoggingUtil loggingUtil = mock(LoggingUtil.class);
+
+        RuntimeStatConfig runtimeConfig = RuntimeStatConfig.defaults();
+        when(gameplayConfigService.getRuntimeStatConfig()).thenReturn(runtimeConfig);
+
+        ResourceNodeInteractionListener listener = new ResourceNodeInteractionListener(
+                plugin,
+                activeNodeManager,
+                nodeRegistryService,
+                lootService,
+                customItemRegistry,
+                playerDataService,
+                gameplayConfigService,
+                loggingUtil);
+
+        World world = mock(World.class);
+        Location nodeLocation = new Location(world, 10, 64, 10);
+        ActiveResourceNode activeNode = new ActiveResourceNode(nodeLocation, "test_node");
+        when(activeNodeManager.getActiveNode(any(Location.class))).thenReturn(Optional.of(activeNode));
+
+        ResourceNodeType nodeType = new ResourceNodeType(
+                "test_node",
+                Material.STONE,
+                2.0,
+                Set.of(Material.WOODEN_PICKAXE),
+                "test_loot",
+                30);
+        when(nodeRegistryService.getNodeType("test_node")).thenReturn(Optional.of(nodeType));
+
+        LootTable lootTable = mock(LootTable.class);
+        ItemStack originalDrop = mock(ItemStack.class);
+        ItemStack clonedDrop = mock(ItemStack.class);
+        AtomicInteger dropAmount = new AtomicInteger(1);
+        when(originalDrop.getAmount()).thenReturn(1);
+        when(originalDrop.clone()).thenReturn(clonedDrop);
+        when(clonedDrop.clone()).thenReturn(clonedDrop);
+        when(clonedDrop.getAmount()).thenAnswer(invocation -> dropAmount.get());
+        doAnswer(invocation -> {
+            dropAmount.set(invocation.getArgument(0));
+            return null;
+        }).when(clonedDrop).setAmount(anyInt());
+        when(lootTable.generateLoot(eq(customItemRegistry), eq(plugin))).thenReturn(List.of(originalDrop));
+        when(lootService.getLootTableById("test_loot")).thenReturn(Optional.of(lootTable));
+
+        Player player = mock(Player.class);
+        UUID playerId = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(playerId);
+        when(player.getName()).thenReturn("Miner");
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        ItemStack heldTool = mock(ItemStack.class);
+        doReturn(Material.WOODEN_PICKAXE).when(heldTool).getType();
+        when(player.getInventory()).thenReturn(inventory);
+        when(inventory.getItemInMainHand()).thenReturn(heldTool);
+        when(player.getWorld()).thenReturn(world);
+        Location playerLocation = new Location(world, 11, 64, 11);
+        when(player.getLocation()).thenReturn(playerLocation);
+
+        PlayerProfile profile = mock(PlayerProfile.class);
+        when(profile.getStatValue(Stat.MINING_SPEED)).thenReturn(160.0);
+        when(profile.getStatValue(Stat.MINING_FORTUNE)).thenReturn(500.0);
+        when(playerDataService.getPlayerProfile(playerId)).thenReturn(profile);
+
+        Block block = mock(Block.class);
+        when(block.getLocation()).thenReturn(nodeLocation);
+
+        BlockBreakEvent event = mock(BlockBreakEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getBlock()).thenReturn(block);
+
+        doReturn(null).when(world).dropItemNaturally(any(), any());
+
+        listener.onBlockBreak(event);
+
+        verify(event).setCancelled(true);
+        verify(event).setDropItems(false);
+        verify(lootTable).generateLoot(customItemRegistry, plugin);
+        ArgumentCaptor<ItemStack> dropCaptor = ArgumentCaptor.forClass(ItemStack.class);
+        verify(world).dropItemNaturally(eq(playerLocation), dropCaptor.capture());
+        assertEquals(clonedDrop, dropCaptor.getValue());
+        assertEquals(2, dropAmount.get());
+        verify(activeNodeManager).depleteNode(activeNode);
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(player).sendMessage(messageCaptor.capture());
+        assertTrue(messageCaptor.getValue().contains("successfully"));
+    }
+}

--- a/src/test/java/com/x1f4r/mmocraft/world/zone/runtime/ZoneStatApplierTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/world/zone/runtime/ZoneStatApplierTest.java
@@ -1,0 +1,67 @@
+package com.x1f4r.mmocraft.world.zone.runtime;
+
+import com.x1f4r.mmocraft.eventbus.EventBusService;
+import com.x1f4r.mmocraft.eventbus.EventHandler;
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.playerdata.runtime.PlayerRuntimeAttributeService;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import com.x1f4r.mmocraft.world.zone.event.PlayerEnterZoneEvent;
+import com.x1f4r.mmocraft.world.zone.event.PlayerLeaveZoneEvent;
+import com.x1f4r.mmocraft.world.zone.model.Zone;
+import com.x1f4r.mmocraft.world.zone.service.ZoneManager;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class ZoneStatApplierTest {
+
+    @Test
+    void appliesAndClearsZoneModifiers() {
+        ZoneManager zoneManager = mock(ZoneManager.class);
+        PlayerDataService playerDataService = mock(PlayerDataService.class);
+        EventBusService eventBusService = mock(EventBusService.class);
+        PlayerRuntimeAttributeService runtimeAttributeService = mock(PlayerRuntimeAttributeService.class);
+        LoggingUtil loggingUtil = mock(LoggingUtil.class);
+
+        ZoneStatApplier applier = new ZoneStatApplier(zoneManager, playerDataService, eventBusService, runtimeAttributeService, loggingUtil);
+        applier.register();
+
+        ArgumentCaptor<EventHandler<PlayerEnterZoneEvent>> enterCaptor = ArgumentCaptor.forClass(EventHandler.class);
+        ArgumentCaptor<EventHandler<PlayerLeaveZoneEvent>> leaveCaptor = ArgumentCaptor.forClass(EventHandler.class);
+        verify(eventBusService).register(eq(PlayerEnterZoneEvent.class), enterCaptor.capture());
+        verify(eventBusService).register(eq(PlayerLeaveZoneEvent.class), leaveCaptor.capture());
+
+        Player player = mock(Player.class);
+        UUID playerId = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(playerId);
+        when(player.getName()).thenReturn("Explorer");
+
+        PlayerProfile profile = mock(PlayerProfile.class);
+        when(playerDataService.getPlayerProfile(playerId)).thenReturn(profile);
+
+        Zone zone = new Zone("ancient_ruins", "Ancient Ruins", "world", 0, 0, 0, 10, 10, 10,
+                Map.<String, Object>of("stat.speed", 5.0, "stat.strength", -2.0));
+
+        enterCaptor.getValue().handle(new PlayerEnterZoneEvent(player, zone));
+
+        ArgumentCaptor<Map<Stat, Double>> modifierCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(profile).setTemporaryStatModifiers(eq("zone:ancient_ruins"), modifierCaptor.capture());
+        assertEquals(2, modifierCaptor.getValue().size());
+        assertEquals(5.0, modifierCaptor.getValue().get(Stat.SPEED));
+        assertEquals(-2.0, modifierCaptor.getValue().get(Stat.STRENGTH));
+        verify(runtimeAttributeService).syncPlayer(player);
+
+        leaveCaptor.getValue().handle(new PlayerLeaveZoneEvent(player, zone));
+        verify(profile).clearTemporaryStatModifiers("zone:ancient_ruins");
+        verify(runtimeAttributeService, times(2)).syncPlayer(player);
+    }
+}


### PR DESCRIPTION
## Summary
- inject pluggable haste effect and attribute resolver handlers into the player runtime attribute service to decouple Bukkit-only types
- refresh runtime attribute, skill, resource node, and admin command tests to rely on the new hooks without server dependencies and tighten behaviour assertions
- ensure resource gathering fortune handling and other listeners operate deterministically for unit testing

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ce4127f1188329ac72b0e7db4f6bd5