### PR TITLE
Add Hypixel-inspired demo showcase content

### DIFF
--- a/src/main/java/com/x1f4r/mmocraft/demo/item/AnglersTidalRod.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/AnglersTidalRod.java
@@ -1,0 +1,84 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.skill.TidalSurgeSkill;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemAbilityDescriptor;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Fishing fortune rod to showcase aquatic professions.
+ */
+public class AnglersTidalRod extends CustomItem {
+
+    public static final String ITEM_ID = "anglers_tidal_rod";
+
+    public AnglersTidalRod(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.FISHING_ROD;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&3Angler's Tidal Rod";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7Commission reward from the tidal fishing outpost.",
+                "&7Ride the currents to secure treasure catches."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.FISHING_FORTUNE, 200.0);
+        mods.put(Stat.MAGIC_FIND, 15.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.EPIC;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<ItemAbilityDescriptor> getAbilityDescriptors() {
+        return List.of(new ItemAbilityDescriptor(
+                TidalSurgeSkill.SKILL_ID,
+                TidalSurgeSkill.DISPLAY_NAME,
+                "Right Click",
+                TidalSurgeSkill.DESCRIPTION,
+                TidalSurgeSkill.MANA_COST,
+                TidalSurgeSkill.COOLDOWN_SECONDS));
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Infusion Altar: refine a fishing rod with prismarine shards, crystals, and nautilus shells from tidal commissions."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/BerserkerGauntlet.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/BerserkerGauntlet.java
@@ -1,0 +1,86 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.skill.BerserkerRageSkill;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemAbilityDescriptor;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Ferocious gauntlet emphasizing melee burst.
+ */
+public class BerserkerGauntlet extends CustomItem {
+
+    public static final String ITEM_ID = "berserker_gauntlet";
+
+    public BerserkerGauntlet(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.NETHERITE_SWORD;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&dBerserker Gauntlet";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7A gauntlet that channels molten fury into each swing.",
+                "&7Unlocks a rage window to shred foes."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.STRENGTH, 60.0);
+        mods.put(Stat.ATTACK_SPEED, 35.0);
+        mods.put(Stat.FEROCITY, 25.0);
+        mods.put(Stat.CRITICAL_CHANCE, 15.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.MYTHIC;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<ItemAbilityDescriptor> getAbilityDescriptors() {
+        return List.of(new ItemAbilityDescriptor(
+                BerserkerRageSkill.SKILL_ID,
+                BerserkerRageSkill.DISPLAY_NAME,
+                "Right Click",
+                BerserkerRageSkill.DESCRIPTION,
+                BerserkerRageSkill.MANA_COST,
+                BerserkerRageSkill.COOLDOWN_SECONDS));
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Infusion Altar: combine a diamond axe, magma cream, rabbit feet, and netherite scrap from mining commissions."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/BlazingEmberRod.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/BlazingEmberRod.java
@@ -1,0 +1,87 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.skill.InfernoBurstSkill;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemAbilityDescriptor;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mythic weapon inspired by Hypixel's Ember Rod.
+ */
+public class BlazingEmberRod extends CustomItem {
+
+    public static final String ITEM_ID = "blazing_ember_rod";
+
+    public BlazingEmberRod(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.BLAZE_ROD;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&cBlazing Ember Rod";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7Forged from the heart of ember commissions.",
+                "&7Excels at ability-based burst damage."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.STRENGTH, 35.0);
+        mods.put(Stat.INTELLIGENCE, 90.0);
+        mods.put(Stat.ABILITY_POWER, 55.0);
+        mods.put(Stat.MANA_REGEN, 15.0);
+        mods.put(Stat.CRITICAL_DAMAGE, 45.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.MYTHIC;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<ItemAbilityDescriptor> getAbilityDescriptors() {
+        return List.of(new ItemAbilityDescriptor(
+                InfernoBurstSkill.SKILL_ID,
+                InfernoBurstSkill.DISPLAY_NAME,
+                "Right Click",
+                InfernoBurstSkill.DESCRIPTION,
+                InfernoBurstSkill.MANA_COST,
+                InfernoBurstSkill.COOLDOWN_SECONDS));
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Infusion Altar: meld blaze rods, magma cream, blaze powder, and ghast tears gathered from ember commissions."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/ForagersHatchet.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/ForagersHatchet.java
@@ -1,0 +1,72 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Foraging fortune tool to complete gathering stat coverage.
+ */
+public class ForagersHatchet extends CustomItem {
+
+    public static final String ITEM_ID = "foragers_hatchet";
+
+    public ForagersHatchet(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.DIAMOND_AXE;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&aForager's Hatchet";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7Balanced axe tuned for grove commissions.",
+                "&7Improves foraging fortune while adding a touch of power."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.FORAGING_FORTUNE, 160.0);
+        mods.put(Stat.STRENGTH, 20.0);
+        mods.put(Stat.SPEED, 10.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.LEGENDARY;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Workbench: combine a diamond axe with freshly cut logs and bone meal from grove commissions."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/GuardianBulwark.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/GuardianBulwark.java
@@ -1,0 +1,72 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defensive legendary chestplate showcasing mitigation stats.
+ */
+public class GuardianBulwark extends CustomItem {
+
+    public static final String ITEM_ID = "guardian_bulwark";
+
+    public GuardianBulwark(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.DIAMOND_CHESTPLATE;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&9Guardian Bulwark";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7Anvil-reinforced plate favored by stalwart tanks.",
+                "&7Massively boosts survivability stats."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.HEALTH, 220.0);
+        mods.put(Stat.DEFENSE, 160.0);
+        mods.put(Stat.TRUE_DEFENSE, 45.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.LEGENDARY;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Workbench: surround a diamond chestplate with iron blocks and diamonds to forge a fortified bulwark."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/HarvestersScythe.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/HarvestersScythe.java
@@ -1,0 +1,84 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.skill.HarvestRallySkill;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemAbilityDescriptor;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Farming fortune tool to highlight island mini-loops.
+ */
+public class HarvestersScythe extends CustomItem {
+
+    public static final String ITEM_ID = "harvesters_scythe";
+
+    public HarvestersScythe(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.NETHERITE_HOE;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&eHarvester's Scythe";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7Designed for farming islands and crop commissions.",
+                "&7Bolsters farming fortune and mobility."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.FARMING_FORTUNE, 180.0);
+        mods.put(Stat.SPEED, 30.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.MYTHIC;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<ItemAbilityDescriptor> getAbilityDescriptors() {
+        return List.of(new ItemAbilityDescriptor(
+                HarvestRallySkill.SKILL_ID,
+                HarvestRallySkill.DISPLAY_NAME,
+                "Right Click",
+                HarvestRallySkill.DESCRIPTION,
+                HarvestRallySkill.MANA_COST,
+                HarvestRallySkill.COOLDOWN_SECONDS));
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Infusion Altar: empower a diamond hoe with hay bales, pumpkins, and sugar cane from farming islands."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/LuckyCharmTalisman.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/LuckyCharmTalisman.java
@@ -1,0 +1,85 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemAbilityDescriptor;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Magic find trinket analogous to SkyBlock accessories.
+ */
+public class LuckyCharmTalisman extends CustomItem {
+
+    public static final String ITEM_ID = "lucky_charm_talisman";
+    private static final String PASSIVE_ABILITY_ID = "lucky_charm_passive";
+
+    public LuckyCharmTalisman(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.EMERALD;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&aLucky Charm";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7Carry in your inventory to boost rare drop luck.",
+                "&7Commission reward from lush farming islands."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.MAGIC_FIND, 50.0);
+        mods.put(Stat.PET_LUCK, 40.0);
+        mods.put(Stat.MANA_REGEN, 5.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.RARE;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<ItemAbilityDescriptor> getAbilityDescriptors() {
+        return List.of(new ItemAbilityDescriptor(
+                PASSIVE_ABILITY_ID,
+                "Fortune's Favor",
+                "Passive",
+                "Passively increases your chance to find valuable loot.",
+                0.0,
+                0.0));
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Workbench: craft using gold ingots, emeralds, rabbit feet, and lapis from farming and mining loops."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/ProspectorsDrill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/ProspectorsDrill.java
@@ -1,0 +1,84 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.skill.ProspectorPulseSkill;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemAbilityDescriptor;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * High tier mining tool that accelerates commissions.
+ */
+public class ProspectorsDrill extends CustomItem {
+
+    public static final String ITEM_ID = "prospectors_drill";
+
+    public ProspectorsDrill(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.NETHERITE_PICKAXE;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&6Prospector's Drill";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7Commission-ready drill that extracts ores at blistering speed.",
+                "&7Pulse it to gain haste and fortune."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.MINING_SPEED, 250.0);
+        mods.put(Stat.MINING_FORTUNE, 150.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.MYTHIC;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<ItemAbilityDescriptor> getAbilityDescriptors() {
+        return List.of(new ItemAbilityDescriptor(
+                ProspectorPulseSkill.SKILL_ID,
+                ProspectorPulseSkill.DISPLAY_NAME,
+                "Right Click",
+                ProspectorPulseSkill.DESCRIPTION,
+                ProspectorPulseSkill.MANA_COST,
+                ProspectorPulseSkill.COOLDOWN_SECONDS));
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Infusion Altar: infuse a diamond pickaxe with redstone blocks, gold blocks, and emeralds from mining commissions."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/WindrunnerBoots.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/WindrunnerBoots.java
@@ -1,0 +1,86 @@
+package com.x1f4r.mmocraft.demo.item;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.skill.GaleForceDashSkill;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.model.ItemAbilityDescriptor;
+import com.x1f4r.mmocraft.item.model.ItemRarity;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Speed-oriented boots inspired by SkyBlock footwear.
+ */
+public class WindrunnerBoots extends CustomItem {
+
+    public static final String ITEM_ID = "windrunner_boots";
+
+    public WindrunnerBoots(MMOCraftPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getItemId() {
+        return ITEM_ID;
+    }
+
+    @Override
+    public Material getMaterial() {
+        return Material.LEATHER_BOOTS;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "&bWindrunner Boots";
+    }
+
+    @Override
+    public List<String> getLore() {
+        return List.of(
+                "&7Lightweight boots woven with phantom membranes.",
+                "&7Pairs with a gust dash for rapid traversal."
+        );
+    }
+
+    @Override
+    public Map<Stat, Double> getStatModifiers() {
+        Map<Stat, Double> mods = new EnumMap<>(Stat.class);
+        mods.put(Stat.SPEED, 90.0);
+        mods.put(Stat.EVASION, 15.0);
+        mods.put(Stat.DEFENSE, 25.0);
+        mods.put(Stat.MAGIC_FIND, 10.0);
+        return mods;
+    }
+
+    @Override
+    public ItemRarity getRarity() {
+        return ItemRarity.LEGENDARY;
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return true;
+    }
+
+    @Override
+    public List<ItemAbilityDescriptor> getAbilityDescriptors() {
+        return List.of(new ItemAbilityDescriptor(
+                GaleForceDashSkill.SKILL_ID,
+                GaleForceDashSkill.DISPLAY_NAME,
+                "Sneak + Right Click",
+                GaleForceDashSkill.DESCRIPTION,
+                GaleForceDashSkill.MANA_COST,
+                GaleForceDashSkill.COOLDOWN_SECONDS));
+    }
+
+    @Override
+    public List<String> getRecipeHints() {
+        return List.of(
+                "Workbench: stitch leather boots with feathers, sugar, and phantom membranes dropped by wind commissions."
+        );
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/BerserkerRageSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/BerserkerRageSkill.java
@@ -1,0 +1,51 @@
+package com.x1f4r.mmocraft.demo.skill;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Frenzy window used by the Berserker Gauntlet.
+ */
+public class BerserkerRageSkill extends Skill {
+
+    public static final String SKILL_ID = "berserker_rage";
+    public static final String DISPLAY_NAME = "Berserker Rage";
+    public static final String DESCRIPTION = "Enter a frenzied state increasing damage and swing speed.";
+    public static final double MANA_COST = 80.0;
+    public static final double COOLDOWN_SECONDS = 25.0;
+    private static final int DURATION_SECONDS = 8;
+
+    public BerserkerRageSkill(MMOCraftPlugin plugin) {
+        super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
+    }
+
+    @Override
+    public void execute(PlayerProfile casterProfile, Entity targetEntity, Location targetLocation) {
+        Player player = Bukkit.getPlayer(casterProfile.getPlayerUUID());
+        if (player == null) {
+            return;
+        }
+
+        int ticks = DURATION_SECONDS * 20;
+        player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, ticks, 1, false, false, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, ticks, 1, false, false, true));
+
+        Location location = player.getLocation();
+        player.getWorld().spawnParticle(Particle.CRIT, location, 50, 0.8, 0.4, 0.8, 0.05);
+        player.getWorld().playSound(location, Sound.ENTITY_PLAYER_ATTACK_SWEEP, 1.0f, 0.8f);
+
+        player.sendMessage(StringUtil.colorize("&cBloodlust surges through your veins!"));
+        applyManaCost(casterProfile);
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/GaleForceDashSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/GaleForceDashSkill.java
@@ -1,0 +1,51 @@
+package com.x1f4r.mmocraft.demo.skill;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Movement burst used by the Windrunner Boots.
+ */
+public class GaleForceDashSkill extends Skill {
+
+    public static final String SKILL_ID = "gale_force_dash";
+    public static final String DISPLAY_NAME = "Gale Force Dash";
+    public static final String DESCRIPTION = "Dash forward on a gust of wind gaining extreme speed.";
+    public static final double MANA_COST = 60.0;
+    public static final double COOLDOWN_SECONDS = 15.0;
+    private static final int DURATION_SECONDS = 6;
+
+    public GaleForceDashSkill(MMOCraftPlugin plugin) {
+        super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
+    }
+
+    @Override
+    public void execute(PlayerProfile casterProfile, Entity targetEntity, Location targetLocation) {
+        Player player = Bukkit.getPlayer(casterProfile.getPlayerUUID());
+        if (player == null) {
+            return;
+        }
+
+        int ticks = DURATION_SECONDS * 20;
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, ticks, 2, false, false, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP_BOOST, ticks, 1, false, false, true));
+
+        Location location = player.getLocation();
+        player.getWorld().spawnParticle(Particle.CLOUD, location, 40, 0.6, 0.2, 0.6, 0.02);
+        player.getWorld().playSound(location, Sound.ENTITY_PHANTOM_FLAP, 1.0f, 1.2f);
+
+        player.sendMessage(StringUtil.colorize("&bWind surges around you, accelerating your stride."));
+        applyManaCost(casterProfile);
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/HarvestRallySkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/HarvestRallySkill.java
@@ -1,0 +1,51 @@
+package com.x1f4r.mmocraft.demo.skill;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Farming rally ability for the Harvester's Scythe.
+ */
+public class HarvestRallySkill extends Skill {
+
+    public static final String SKILL_ID = "harvest_rally";
+    public static final String DISPLAY_NAME = "Harvest Rally";
+    public static final String DESCRIPTION = "Bolster your farming speed and nourishment.";
+    public static final double MANA_COST = 45.0;
+    public static final double COOLDOWN_SECONDS = 20.0;
+    private static final int DURATION_SECONDS = 10;
+
+    public HarvestRallySkill(MMOCraftPlugin plugin) {
+        super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
+    }
+
+    @Override
+    public void execute(PlayerProfile casterProfile, Entity targetEntity, Location targetLocation) {
+        Player player = Bukkit.getPlayer(casterProfile.getPlayerUUID());
+        if (player == null) {
+            return;
+        }
+
+        int ticks = DURATION_SECONDS * 20;
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, ticks, 0, false, false, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, ticks, 1, false, false, true));
+
+        Location location = player.getLocation();
+        player.getWorld().spawnParticle(Particle.HAPPY_VILLAGER, location, 45, 0.6, 0.5, 0.6, 0.05);
+        player.getWorld().playSound(location, Sound.BLOCK_CROP_BREAK, 1.0f, 1.1f);
+
+        player.sendMessage(StringUtil.colorize("&aYou feel invigorated to reap every crop."));
+        applyManaCost(casterProfile);
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/InfernoBurstSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/InfernoBurstSkill.java
@@ -1,0 +1,71 @@
+package com.x1f4r.mmocraft.demo.skill;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+/**
+ * High impact AOE ability used by the Blazing Ember Rod.
+ */
+public class InfernoBurstSkill extends Skill {
+
+    public static final String SKILL_ID = "inferno_burst";
+    public static final String DISPLAY_NAME = "Inferno Burst";
+    public static final String DESCRIPTION = "Ignites enemies in front of you with ability-scaled flame damage.";
+    public static final double MANA_COST = 120.0;
+    public static final double COOLDOWN_SECONDS = 20.0;
+    private static final double BASE_DAMAGE = 60.0;
+    private static final double INT_SCALING = 0.6;
+    private static final double ABILITY_POWER_SCALING = 0.9;
+    private static final double EFFECT_RADIUS = 5.0;
+    private static final int FIRE_TICKS = 100;
+
+    public InfernoBurstSkill(MMOCraftPlugin plugin) {
+        super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_AOE_POINT);
+    }
+
+    @Override
+    public void execute(PlayerProfile casterProfile, Entity targetEntity, Location targetLocation) {
+        Player caster = Bukkit.getPlayer(casterProfile.getPlayerUUID());
+        if (caster == null) {
+            return;
+        }
+
+        Location center = targetLocation != null ? targetLocation.clone() : caster.getLocation();
+        World world = center.getWorld();
+        if (world == null) {
+            return;
+        }
+
+        double damage = BASE_DAMAGE
+                + casterProfile.getStatValue(Stat.INTELLIGENCE) * INT_SCALING
+                + casterProfile.getStatValue(Stat.ABILITY_POWER) * ABILITY_POWER_SCALING;
+        damage = Math.max(0.0, damage);
+
+        for (Entity entity : world.getNearbyEntities(center, EFFECT_RADIUS, EFFECT_RADIUS, EFFECT_RADIUS)) {
+            if (!(entity instanceof LivingEntity living) || entity.equals(caster)) {
+                continue;
+            }
+            living.damage(damage, caster);
+            living.setFireTicks(FIRE_TICKS);
+        }
+
+        world.spawnParticle(Particle.FLAME, center, 80, 1.25, 0.5, 1.25, 0.05);
+        world.spawnParticle(Particle.LARGE_SMOKE, center, 40, 1.25, 0.5, 1.25, 0.01);
+        world.playSound(center, Sound.ITEM_FIRECHARGE_USE, 1.0f, 0.75f);
+
+        caster.sendMessage(StringUtil.colorize("&6You unleash an inferno of flames!"));
+        applyManaCost(casterProfile);
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/ProspectorPulseSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/ProspectorPulseSkill.java
@@ -1,0 +1,51 @@
+package com.x1f4r.mmocraft.demo.skill;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Temporary mining buff tied to the Prospector's Drill.
+ */
+public class ProspectorPulseSkill extends Skill {
+
+    public static final String SKILL_ID = "prospector_pulse";
+    public static final String DISPLAY_NAME = "Prospector Pulse";
+    public static final String DESCRIPTION = "Charges your drill with haste and fortune.";
+    public static final double MANA_COST = 50.0;
+    public static final double COOLDOWN_SECONDS = 24.0;
+    private static final int DURATION_SECONDS = 10;
+
+    public ProspectorPulseSkill(MMOCraftPlugin plugin) {
+        super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
+    }
+
+    @Override
+    public void execute(PlayerProfile casterProfile, Entity targetEntity, Location targetLocation) {
+        Player player = Bukkit.getPlayer(casterProfile.getPlayerUUID());
+        if (player == null) {
+            return;
+        }
+
+        int ticks = DURATION_SECONDS * 20;
+        player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, ticks, 2, false, false, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.LUCK, ticks, 1, false, false, true));
+
+        Location location = player.getLocation();
+        player.getWorld().spawnParticle(Particle.ENCHANTED_HIT, location, 60, 0.6, 0.4, 0.6, 0.1);
+        player.getWorld().playSound(location, Sound.BLOCK_AMETHYST_BLOCK_CHIME, 1.0f, 1.0f);
+
+        player.sendMessage(StringUtil.colorize("&eYour drill hums with prospecting energy."));
+        applyManaCost(casterProfile);
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/TidalSurgeSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/TidalSurgeSkill.java
@@ -1,0 +1,51 @@
+package com.x1f4r.mmocraft.demo.skill;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Fishing-focused ability for the Angler's Tidal Rod.
+ */
+public class TidalSurgeSkill extends Skill {
+
+    public static final String SKILL_ID = "tidal_surge";
+    public static final String DISPLAY_NAME = "Tidal Surge";
+    public static final String DESCRIPTION = "Ride a watery current, improving aquatic treasure chances.";
+    public static final double MANA_COST = 65.0;
+    public static final double COOLDOWN_SECONDS = 22.0;
+    private static final int DURATION_SECONDS = 8;
+
+    public TidalSurgeSkill(MMOCraftPlugin plugin) {
+        super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
+    }
+
+    @Override
+    public void execute(PlayerProfile casterProfile, Entity targetEntity, Location targetLocation) {
+        Player player = Bukkit.getPlayer(casterProfile.getPlayerUUID());
+        if (player == null) {
+            return;
+        }
+
+        int ticks = DURATION_SECONDS * 20;
+        player.addPotionEffect(new PotionEffect(PotionEffectType.DOLPHINS_GRACE, ticks, 0, false, false, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.LUCK, ticks, 1, false, false, true));
+
+        Location location = player.getLocation();
+        player.getWorld().spawnParticle(Particle.SPLASH, location, 60, 0.8, 0.5, 0.8, 0.1);
+        player.getWorld().playSound(location, Sound.ENTITY_DOLPHIN_PLAY, 1.0f, 1.0f);
+
+        player.sendMessage(StringUtil.colorize("&3Currents propel you toward bountiful catches."));
+        applyManaCost(casterProfile);
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/item/model/ItemAbilityDescriptor.java
+++ b/src/main/java/com/x1f4r/mmocraft/item/model/ItemAbilityDescriptor.java
@@ -1,0 +1,44 @@
+package com.x1f4r.mmocraft.item.model;
+
+import java.util.Objects;
+
+/**
+ * Describes an active or passive ability that can be attached to a custom item.
+ * These descriptors drive tooltip generation, admin summaries, and NBT metadata
+ * so that gameplay systems can discover which skills/items are linked together.
+ */
+public record ItemAbilityDescriptor(String abilityId,
+                                    String displayName,
+                                    String activationHint,
+                                    String summary,
+                                    double manaCost,
+                                    double cooldownSeconds) {
+
+    public ItemAbilityDescriptor {
+        Objects.requireNonNull(abilityId, "abilityId");
+        Objects.requireNonNull(displayName, "displayName");
+        activationHint = activationHint == null ? "" : activationHint;
+        summary = summary == null ? "" : summary;
+    }
+
+    /**
+     * @return {@code true} if the descriptor includes descriptive text.
+     */
+    public boolean hasSummary() {
+        return summary != null && !summary.isBlank();
+    }
+
+    /**
+     * @return {@code true} if the ability consumes mana when activated.
+     */
+    public boolean consumesMana() {
+        return manaCost > 0.0;
+    }
+
+    /**
+     * @return {@code true} if the ability applies a cooldown on use.
+     */
+    public boolean hasCooldown() {
+        return cooldownSeconds > 0.0;
+    }
+}

--- a/src/main/resources/config/crafting.toml
+++ b/src/main/resources/config/crafting.toml
@@ -1,8 +1,9 @@
 # ------------------------------------------------------------
 # Custom crafting recipes
 # ------------------------------------------------------------
-# Recipes are disabled by default to preserve current behaviour.
-# Flip "enabled" to true and reload to activate them.
+# Demo progression recipes ship enabled so the showcase loop
+# is available out of the box. Toggle individual entries as
+# desired for custom deployments.
 # ------------------------------------------------------------
 
 [[recipes]]
@@ -25,3 +26,147 @@ quantity = 2
 type = "VANILLA"
 id = "STICK"
 quantity = 1
+
+[[recipes]]
+id = "windrunner_boots"
+enabled = true
+type = "CUSTOM_SHAPELESS"
+permission = ""
+
+[recipes.output]
+type = "CUSTOM"
+id = "windrunner_boots"
+amount = 1
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "LEATHER_BOOTS"
+quantity = 1
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "FEATHER"
+quantity = 4
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "SUGAR"
+quantity = 4
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "PHANTOM_MEMBRANE"
+quantity = 2
+
+[[recipes]]
+id = "guardian_bulwark"
+enabled = true
+type = "CUSTOM_SHAPED"
+permission = ""
+
+[recipes.output]
+type = "CUSTOM"
+id = "guardian_bulwark"
+amount = 1
+
+[recipes.shaped."0"]
+type = "VANILLA"
+id = "IRON_BLOCK"
+quantity = 1
+
+[recipes.shaped."1"]
+type = "VANILLA"
+id = "DIAMOND"
+quantity = 1
+
+[recipes.shaped."2"]
+type = "VANILLA"
+id = "IRON_BLOCK"
+quantity = 1
+
+[recipes.shaped."3"]
+type = "VANILLA"
+id = "DIAMOND"
+quantity = 1
+
+[recipes.shaped."4"]
+type = "VANILLA"
+id = "DIAMOND_CHESTPLATE"
+quantity = 1
+
+[recipes.shaped."5"]
+type = "VANILLA"
+id = "DIAMOND"
+quantity = 1
+
+[recipes.shaped."6"]
+type = "VANILLA"
+id = "IRON_BLOCK"
+quantity = 1
+
+[recipes.shaped."7"]
+type = "VANILLA"
+id = "DIAMOND"
+quantity = 1
+
+[recipes.shaped."8"]
+type = "VANILLA"
+id = "IRON_BLOCK"
+quantity = 1
+
+[[recipes]]
+id = "lucky_charm"
+enabled = true
+type = "CUSTOM_SHAPELESS"
+permission = ""
+
+[recipes.output]
+type = "CUSTOM"
+id = "lucky_charm_talisman"
+amount = 1
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "GOLD_INGOT"
+quantity = 2
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "EMERALD"
+quantity = 1
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "RABBIT_FOOT"
+quantity = 1
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "LAPIS_LAZULI"
+quantity = 4
+
+[[recipes]]
+id = "foragers_hatchet"
+enabled = true
+type = "CUSTOM_SHAPELESS"
+permission = ""
+
+[recipes.output]
+type = "CUSTOM"
+id = "foragers_hatchet"
+amount = 1
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "DIAMOND_AXE"
+quantity = 1
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "OAK_LOG"
+quantity = 8
+
+[[recipes.ingredients]]
+type = "VANILLA"
+id = "BONE_MEAL"
+quantity = 4

--- a/src/main/resources/config/demo-content.yml
+++ b/src/main/resources/config/demo-content.yml
@@ -50,6 +50,125 @@ loot-tables:
           chance: 0.25
           min: 1
           max: 1
+    - table-id: farming_patch_loot
+      entries:
+        - type: VANILLA
+          id: WHEAT
+          chance: 0.9
+          min: 2
+          max: 5
+        - type: VANILLA
+          id: CARROT
+          chance: 0.5
+          min: 1
+          max: 3
+        - type: VANILLA
+          id: PUMPKIN
+          chance: 0.25
+          min: 1
+          max: 1
+    - table-id: herbal_patch_loot
+      entries:
+        - type: VANILLA
+          id: SUGAR_CANE
+          chance: 0.85
+          min: 2
+          max: 5
+        - type: VANILLA
+          id: MELON_SLICE
+          chance: 0.5
+          min: 1
+          max: 3
+        - type: VANILLA
+          id: RABBIT_FOOT
+          chance: 0.2
+          min: 1
+          max: 1
+    - table-id: grove_commission_loot
+      entries:
+        - type: VANILLA
+          id: OAK_LOG
+          chance: 1.0
+          min: 1
+          max: 3
+        - type: VANILLA
+          id: STICK
+          chance: 0.75
+          min: 2
+          max: 4
+        - type: VANILLA
+          id: BONE_MEAL
+          chance: 0.4
+          min: 1
+          max: 2
+    - table-id: mining_commission_loot
+      entries:
+        - type: VANILLA
+          id: RAW_GOLD
+          chance: 0.65
+          min: 1
+          max: 2
+        - type: VANILLA
+          id: REDSTONE
+          chance: 0.8
+          min: 3
+          max: 6
+        - type: VANILLA
+          id: EMERALD
+          chance: 0.35
+          min: 1
+          max: 2
+        - type: VANILLA
+          id: NETHERITE_SCRAP
+          chance: 0.1
+          min: 1
+          max: 1
+    - table-id: ember_commission_loot
+      entries:
+        - type: VANILLA
+          id: MAGMA_CREAM
+          chance: 0.75
+          min: 1
+          max: 2
+        - type: VANILLA
+          id: BLAZE_POWDER
+          chance: 0.9
+          min: 2
+          max: 4
+        - type: VANILLA
+          id: GHAST_TEAR
+          chance: 0.25
+          min: 1
+          max: 1
+    - table-id: wind_commission_loot
+      entries:
+        - type: VANILLA
+          id: PHANTOM_MEMBRANE
+          chance: 0.45
+          min: 1
+          max: 2
+        - type: VANILLA
+          id: FEATHER
+          chance: 0.8
+          min: 2
+          max: 5
+    - table-id: tidal_commission_loot
+      entries:
+        - type: VANILLA
+          id: PRISMARINE_SHARD
+          chance: 0.75
+          min: 1
+          max: 3
+        - type: VANILLA
+          id: PRISMARINE_CRYSTALS
+          chance: 0.6
+          min: 1
+          max: 2
+        - type: VANILLA
+          id: NAUTILUS_SHELL
+          chance: 0.2
+          min: 1
+          max: 1
 
 resource-nodes:
   types:
@@ -76,6 +195,79 @@ resource-nodes:
       loot-table-id: iron_ore_node_loot
       respawn-seconds: 180
       display-name: "&fIron Vein"
+    - type-id: farming_patch
+      block: HAY_BLOCK
+      harvest-seconds: 6.0
+      required-tools:
+        - WOODEN_HOE
+        - STONE_HOE
+        - IRON_HOE
+        - DIAMOND_HOE
+        - NETHERITE_HOE
+      loot-table-id: farming_patch_loot
+      respawn-seconds: 45
+      display-name: "&eFarming Plot"
+    - type-id: herbal_patch
+      block: MOSS_BLOCK
+      harvest-seconds: 6.0
+      required-tools:
+        - WOODEN_HOE
+        - STONE_HOE
+        - IRON_HOE
+        - DIAMOND_HOE
+        - NETHERITE_HOE
+      loot-table-id: herbal_patch_loot
+      respawn-seconds: 45
+      display-name: "&aHerbal Patch"
+    - type-id: grove_commission
+      block: OAK_LOG
+      harvest-seconds: 8.0
+      required-tools:
+        - WOODEN_AXE
+        - STONE_AXE
+        - IRON_AXE
+        - DIAMOND_AXE
+        - NETHERITE_AXE
+      loot-table-id: grove_commission_loot
+      respawn-seconds: 90
+      display-name: "&2Grove Clearing"
+    - type-id: mining_commission
+      block: DEEPSLATE_REDSTONE_ORE
+      harvest-seconds: 12.0
+      required-tools:
+        - IRON_PICKAXE
+        - DIAMOND_PICKAXE
+        - NETHERITE_PICKAXE
+      loot-table-id: mining_commission_loot
+      respawn-seconds: 120
+      display-name: "&6Commission Lode"
+    - type-id: ember_commission
+      block: MAGMA_BLOCK
+      harvest-seconds: 14.0
+      required-tools:
+        - DIAMOND_PICKAXE
+        - NETHERITE_PICKAXE
+      loot-table-id: ember_commission_loot
+      respawn-seconds: 150
+      display-name: "&cEmber Commission"
+    - type-id: wind_commission
+      block: WHITE_WOOL
+      harvest-seconds: 5.0
+      required-tools:
+        - SHEARS
+      loot-table-id: wind_commission_loot
+      respawn-seconds: 60
+      display-name: "&bWind Tossed Nest"
+    - type-id: tidal_commission
+      block: PRISMARINE
+      harvest-seconds: 10.0
+      required-tools:
+        - IRON_PICKAXE
+        - DIAMOND_PICKAXE
+        - NETHERITE_PICKAXE
+      loot-table-id: tidal_commission_loot
+      respawn-seconds: 120
+      display-name: "&3Tidal Cache"
   placements:
     - node-type-id: stone_node
       x: 10
@@ -89,6 +281,42 @@ resource-nodes:
       x: 10
       y: 60
       z: 12
+    - node-type-id: farming_patch
+      x: 20
+      y: 64
+      z: 20
+    - node-type-id: farming_patch
+      x: 22
+      y: 64
+      z: 20
+    - node-type-id: herbal_patch
+      x: 24
+      y: 64
+      z: 20
+    - node-type-id: grove_commission
+      x: 20
+      y: 64
+      z: 24
+    - node-type-id: mining_commission
+      x: 30
+      y: 60
+      z: 10
+    - node-type-id: mining_commission
+      x: 32
+      y: 60
+      z: 10
+    - node-type-id: ember_commission
+      x: 28
+      y: 58
+      z: 8
+    - node-type-id: wind_commission
+      x: 18
+      y: 70
+      z: 18
+    - node-type-id: tidal_commission
+      x: 35
+      y: 62
+      z: 14
 
 custom-spawns:
   - rule-id: plains_skeletal_warriors_night

--- a/src/test/java/com/x1f4r/mmocraft/crafting/service/BasicRecipeRegistryServiceShowcaseTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/crafting/service/BasicRecipeRegistryServiceShowcaseTest.java
@@ -1,0 +1,103 @@
+package com.x1f4r.mmocraft.crafting.service;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.crafting.model.CustomRecipeIngredient;
+import com.x1f4r.mmocraft.crafting.model.RecipeType;
+import com.x1f4r.mmocraft.crafting.recipe.CustomRecipe;
+import com.x1f4r.mmocraft.item.service.CustomItemRegistry;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BasicRecipeRegistryServiceShowcaseTest {
+
+    @Mock
+    private MMOCraftPlugin plugin;
+    @Mock
+    private LoggingUtil loggingUtil;
+    @Mock
+    private CustomItemRegistry itemRegistry;
+
+    private BasicRecipeRegistryService recipeRegistryService;
+
+    @BeforeEach
+    void setUp() {
+        recipeRegistryService = new BasicRecipeRegistryService(plugin, loggingUtil, itemRegistry);
+    }
+
+    @Test
+    void findMatchingRecipe_windrunnerBootsMatchesRegardlessOfOrder() {
+        recipeRegistryService.registerRecipe(createWindrunnerRecipe());
+
+        Inventory grid = mock(Inventory.class);
+        ItemStack[] contents = new ItemStack[9];
+        contents[0] = mockStack("FEATHER", 4);
+        contents[1] = mockStack("SUGAR", 4);
+        contents[2] = mockStack("LEATHER_BOOTS", 1);
+        contents[3] = mockStack("PHANTOM_MEMBRANE", 2);
+        when(grid.getContents()).thenReturn(contents);
+        when(grid.getSize()).thenReturn(contents.length);
+
+        Optional<CustomRecipe> match = recipeRegistryService.findMatchingRecipe(RecipeType.CUSTOM_SHAPELESS, grid);
+        assertTrue(match.isPresent());
+        assertEquals("windrunner_boots", match.get().getRecipeId());
+    }
+
+    @Test
+    void findMatchingRecipe_windrunnerBootsFailsWhenQuantitiesMissing() {
+        recipeRegistryService.registerRecipe(createWindrunnerRecipe());
+
+        Inventory grid = mock(Inventory.class);
+        ItemStack[] contents = new ItemStack[9];
+        contents[0] = mockStack("FEATHER", 4);
+        contents[1] = mockStack("SUGAR", 4);
+        contents[2] = mockStack("LEATHER_BOOTS", 1);
+        contents[3] = mockStack("PHANTOM_MEMBRANE", 1); // Not enough membranes
+        when(grid.getContents()).thenReturn(contents);
+        when(grid.getSize()).thenReturn(contents.length);
+
+        Optional<CustomRecipe> match = recipeRegistryService.findMatchingRecipe(RecipeType.CUSTOM_SHAPELESS, grid);
+        assertFalse(match.isPresent());
+    }
+
+    private CustomRecipe createWindrunnerRecipe() {
+        ItemStack output = mockStack("LEATHER_BOOTS", 1);
+        List<CustomRecipeIngredient> ingredients = List.of(
+                new CustomRecipeIngredient(CustomRecipeIngredient.IngredientType.VANILLA_MATERIAL, "LEATHER_BOOTS", 1),
+                new CustomRecipeIngredient(CustomRecipeIngredient.IngredientType.VANILLA_MATERIAL, "FEATHER", 4),
+                new CustomRecipeIngredient(CustomRecipeIngredient.IngredientType.VANILLA_MATERIAL, "SUGAR", 4),
+                new CustomRecipeIngredient(CustomRecipeIngredient.IngredientType.VANILLA_MATERIAL, "PHANTOM_MEMBRANE", 2)
+        );
+        return new CustomRecipe("windrunner_boots", output, RecipeType.CUSTOM_SHAPELESS, ingredients, null);
+    }
+
+    private ItemStack mockStack(String materialName, int amount) {
+        ItemStack stack = mock(ItemStack.class);
+        Material material = mock(Material.class);
+        when(material.name()).thenReturn(materialName);
+        when(material.isAir()).thenReturn(false);
+        when(stack.getType()).thenReturn(material);
+        when(stack.getAmount()).thenReturn(amount);
+        when(stack.clone()).thenReturn(stack);
+        return stack;
+    }
+}

--- a/src/test/java/com/x1f4r/mmocraft/demo/DemoContentModuleShowcaseTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/demo/DemoContentModuleShowcaseTest.java
@@ -1,0 +1,215 @@
+package com.x1f4r.mmocraft.demo;
+
+import com.x1f4r.mmocraft.config.gameplay.DemoContentConfig;
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.crafting.recipe.CustomRecipe;
+import com.x1f4r.mmocraft.crafting.service.RecipeRegistryService;
+import com.x1f4r.mmocraft.demo.item.AnglersTidalRod;
+import com.x1f4r.mmocraft.demo.item.BerserkerGauntlet;
+import com.x1f4r.mmocraft.demo.item.BlazingEmberRod;
+import com.x1f4r.mmocraft.demo.item.ForagersHatchet;
+import com.x1f4r.mmocraft.demo.item.GuardianBulwark;
+import com.x1f4r.mmocraft.demo.item.HarvestersScythe;
+import com.x1f4r.mmocraft.demo.item.LuckyCharmTalisman;
+import com.x1f4r.mmocraft.demo.item.ProspectorsDrill;
+import com.x1f4r.mmocraft.demo.item.WindrunnerBoots;
+import com.x1f4r.mmocraft.demo.skill.BerserkerRageSkill;
+import com.x1f4r.mmocraft.demo.skill.GaleForceDashSkill;
+import com.x1f4r.mmocraft.demo.skill.HarvestRallySkill;
+import com.x1f4r.mmocraft.demo.skill.InfernoBurstSkill;
+import com.x1f4r.mmocraft.demo.skill.ProspectorPulseSkill;
+import com.x1f4r.mmocraft.demo.skill.TidalSurgeSkill;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.item.service.CustomItemRegistry;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.service.SkillRegistryService;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DemoContentModuleShowcaseTest {
+
+    @Mock
+    private MMOCraftPlugin plugin;
+    @Mock
+    private LoggingUtil loggingUtil;
+    @Mock
+    private CustomItemRegistry itemRegistry;
+    @Mock
+    private SkillRegistryService skillRegistry;
+    @Mock
+    private RecipeRegistryService recipeRegistry;
+
+    private DemoContentModule module;
+
+    private Map<String, CustomItem> registeredItems;
+    private Map<String, Skill> registeredSkills;
+    private Map<String, CustomRecipe> registeredRecipes;
+    private Map<String, ItemStack> itemStacks;
+
+    @BeforeEach
+    void setUp() {
+        DemoContentConfig config = new DemoContentConfig(
+                new DemoContentConfig.DemoToggles(true, true, true, false, false, false, false),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+
+        when(plugin.getLoggingUtil()).thenReturn(loggingUtil);
+        when(plugin.getCustomItemRegistry()).thenReturn(itemRegistry);
+        when(plugin.getSkillRegistryService()).thenReturn(skillRegistry);
+        when(plugin.getRecipeRegistryService()).thenReturn(recipeRegistry);
+        when(plugin.getName()).thenReturn("mmocraft");
+
+        registeredItems = new HashMap<>();
+        itemStacks = new HashMap<>();
+        doAnswer(invocation -> {
+            CustomItem item = invocation.getArgument(0);
+            CustomItem spyItem = spy(item);
+            ItemStack stack = mock(ItemStack.class);
+            Material materialStub = mock(Material.class);
+            when(materialStub.name()).thenReturn(item.getItemId().toUpperCase(Locale.ROOT));
+            when(materialStub.isAir()).thenReturn(false);
+            when(stack.getType()).thenReturn(materialStub);
+            when(stack.getAmount()).thenReturn(1);
+            when(stack.clone()).thenReturn(stack);
+            doReturn(stack).when(spyItem).createItemStack(anyInt());
+            registeredItems.put(spyItem.getItemId(), spyItem);
+            itemStacks.put(spyItem.getItemId(), stack);
+            return null;
+        }).when(itemRegistry).registerItem(any(CustomItem.class));
+        when(itemRegistry.getCustomItem(anyString())).thenAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            return Optional.ofNullable(registeredItems.get(id));
+        });
+        when(itemRegistry.unregisterItem(anyString())).thenAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            itemStacks.remove(id);
+            return registeredItems.remove(id) != null;
+        });
+
+        registeredSkills = new HashMap<>();
+        doAnswer(invocation -> {
+            Skill skill = invocation.getArgument(0);
+            registeredSkills.put(skill.getSkillId(), skill);
+            return null;
+        }).when(skillRegistry).registerSkill(any(Skill.class));
+        when(skillRegistry.getSkill(anyString())).thenAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            return Optional.ofNullable(registeredSkills.get(id));
+        });
+        when(skillRegistry.unregisterSkill(anyString())).thenAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            return registeredSkills.remove(id) != null;
+        });
+
+        registeredRecipes = new HashMap<>();
+        doAnswer(invocation -> {
+            CustomRecipe recipe = invocation.getArgument(0);
+            registeredRecipes.put(recipe.getRecipeId().toLowerCase(Locale.ROOT), recipe);
+            return null;
+        }).when(recipeRegistry).registerRecipe(any(CustomRecipe.class));
+        when(recipeRegistry.getRecipeById(anyString())).thenAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            return Optional.ofNullable(registeredRecipes.get(id.toLowerCase(Locale.ROOT)));
+        });
+        when(recipeRegistry.unregisterRecipe(anyString())).thenAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            return registeredRecipes.remove(id.toLowerCase(Locale.ROOT)) != null;
+        });
+
+        module = new DemoContentModule(plugin, loggingUtil, config);
+    }
+
+    @Test
+    void applySettings_registersShowcaseContentWithoutIdCollisions() {
+        DemoContentSettings settings = new DemoContentSettings(true, true, true, false, false, false, false);
+
+        module.applySettings(settings);
+
+        Set<String> expectedItems = Set.of(
+                "simple_sword",
+                "training_chestplate",
+                BlazingEmberRod.ITEM_ID,
+                WindrunnerBoots.ITEM_ID,
+                GuardianBulwark.ITEM_ID,
+                BerserkerGauntlet.ITEM_ID,
+                LuckyCharmTalisman.ITEM_ID,
+                ProspectorsDrill.ITEM_ID,
+                HarvestersScythe.ITEM_ID,
+                ForagersHatchet.ITEM_ID,
+                AnglersTidalRod.ITEM_ID
+        );
+        assertEquals(expectedItems, registeredItems.keySet());
+
+        Set<String> expectedSkills = Set.of(
+                "strong_strike",
+                "minor_heal",
+                InfernoBurstSkill.SKILL_ID,
+                GaleForceDashSkill.SKILL_ID,
+                BerserkerRageSkill.SKILL_ID,
+                ProspectorPulseSkill.SKILL_ID,
+                HarvestRallySkill.SKILL_ID,
+                TidalSurgeSkill.SKILL_ID
+        );
+        assertEquals(expectedSkills, registeredSkills.keySet());
+
+        Map<String, String> expectedRecipes = Map.of(
+                "infusion_blazing_ember_rod", BlazingEmberRod.ITEM_ID,
+                "infusion_berserker_gauntlet", BerserkerGauntlet.ITEM_ID,
+                "infusion_prospectors_drill", ProspectorsDrill.ITEM_ID,
+                "infusion_harvesters_scythe", HarvestersScythe.ITEM_ID,
+                "infusion_anglers_rod", AnglersTidalRod.ITEM_ID
+        );
+        assertEquals(expectedRecipes.keySet(), registeredRecipes.keySet());
+
+        expectedRecipes.forEach((recipeId, itemId) -> {
+            CustomRecipe recipe = registeredRecipes.get(recipeId);
+            assertNotNull(recipe, "Recipe not registered: " + recipeId);
+            assertSame(itemStacks.get(itemId), recipe.getOutputItemStack(), "Recipe output mismatch for " + recipeId);
+        });
+
+        module.applySettings(settings);
+
+        assertEquals(expectedItems, registeredItems.keySet());
+        assertEquals(expectedSkills, registeredSkills.keySet());
+        assertEquals(expectedRecipes.keySet(), registeredRecipes.keySet());
+
+        verify(itemRegistry, times(expectedItems.size() * 2)).registerItem(any(CustomItem.class));
+        verify(skillRegistry, times(expectedSkills.size() * 2)).registerSkill(any(Skill.class));
+        verify(recipeRegistry, times(expectedRecipes.size() * 2)).registerRecipe(any(CustomRecipe.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add an `ItemAbilityDescriptor` model and extend `CustomItem` metadata to surface abilities, hints, and lore/NBT wiring
- implement Hypixel-inspired demo gear, associated skills, and infusion recipes with supporting config updates for the demo professions loop
- enhance `/mmocadm item list` output and add coverage to ensure the new registries and recipes register and match correctly

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ce4cbb43e083298d8b4c360c321892