### PR TITLE
Add companion pets, HUD, and advanced demo abilities

### DIFF
--- a/src/main/java/com/x1f4r/mmocraft/command/commands/admin/CombatAdminCommand.java
+++ b/src/main/java/com/x1f4r/mmocraft/command/commands/admin/CombatAdminCommand.java
@@ -1,24 +1,20 @@
 package com.x1f4r.mmocraft.command.commands.admin;
 
 import com.x1f4r.mmocraft.command.AbstractPluginCommand;
+import com.x1f4r.mmocraft.command.CommandExecutable;
 import com.x1f4r.mmocraft.combat.model.DamageInstance;
 import com.x1f4r.mmocraft.combat.model.DamageType;
 import com.x1f4r.mmocraft.combat.service.DamageCalculationService;
 import com.x1f4r.mmocraft.core.MMOCraftPlugin;
-import com.x1f4r.mmocraft.command.CommandExecutable;
 import com.x1f4r.mmocraft.util.LoggingUtil;
 import com.x1f4r.mmocraft.util.StringUtil;
-
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import java.util.Collections;
-import org.bukkit.inventory.ItemStack;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -68,6 +64,23 @@ public class CombatAdminCommand extends AbstractPluginCommand {
 
             @Override
             public List<String> onTabComplete(CommandSender sender, String[] args) {
+                if (!sender.hasPermission(PERM_COMBAT_TESTDAMAGE)) {
+                    return Collections.emptyList();
+                }
+                if (args.length == 0) {
+                    return Collections.emptyList();
+                }
+                if (args.length == 1 || args.length == 2) {
+                    return null; // Delegate to Bukkit for player name completion
+                }
+                if (args.length == 3) {
+                    String prefix = args[2].toLowerCase();
+                    return VANILLA_WEAPON_DAMAGE_MAP.keySet().stream()
+                            .map(Enum::name)
+                            .filter(name -> name.toLowerCase().startsWith(prefix))
+                            .sorted()
+                            .collect(Collectors.toList());
+                }
                 return Collections.emptyList();
             }
         });
@@ -150,34 +163,6 @@ public class CombatAdminCommand extends AbstractPluginCommand {
 
     @Override
     public List<String> onTabComplete(CommandSender sender, String[] args) {
-        // args[0] is "combat" (this command's name as a subcommand of /mmocadm)
-        // args[1] is the subcommand of "combat" (e.g., "testdamage")
-        // args[2] is first arg for "testdamage" (attackerName)
-        // args[3] is second arg for "testdamage" (victimName)
-        // args[4] is third arg for "testdamage" (weaponMaterialName)
-
-        String currentCmdArg = args[args.length -1].toLowerCase();
-
-        if (args.length == 2) { // Suggest subcommand names
-            return subCommands.keySet().stream()
-                    .filter(name -> name.startsWith(args[1].toLowerCase()))
-                    .collect(Collectors.toList());
-        }
-
-        String combatSubCommand = args[1].toLowerCase();
-
-        if (combatSubCommand.equals("testdamage")) {
-            if (!sender.hasPermission(PERM_COMBAT_TESTDAMAGE)) return Collections.emptyList();
-            if (args.length == 3 || args.length == 4) { // Attacker or Victim name
-                return null; // Bukkit default player name completion
-            }
-            if (args.length == 5) { // Weapon Material
-                return VANILLA_WEAPON_DAMAGE_MAP.keySet().stream()
-                        .map(Enum::name)
-                        .filter(name -> name.toLowerCase().startsWith(currentCmdArg))
-                        .collect(Collectors.toList());
-            }
-        }
         return Collections.emptyList();
     }
 }

--- a/src/main/java/com/x1f4r/mmocraft/demo/DemoContentModule.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/DemoContentModule.java
@@ -17,6 +17,7 @@ import com.x1f4r.mmocraft.demo.skill.BerserkerRageSkill;
 import com.x1f4r.mmocraft.demo.skill.GaleForceDashSkill;
 import com.x1f4r.mmocraft.demo.skill.HarvestRallySkill;
 import com.x1f4r.mmocraft.demo.skill.InfernoBurstSkill;
+import com.x1f4r.mmocraft.demo.skill.LuckySpriteSummonSkill;
 import com.x1f4r.mmocraft.demo.skill.MinorHealSkill;
 import com.x1f4r.mmocraft.demo.skill.ProspectorPulseSkill;
 import com.x1f4r.mmocraft.demo.skill.StrongStrikeSkill;
@@ -272,6 +273,7 @@ public final class DemoContentModule {
         registerSkillIfAbsent(registry, new ProspectorPulseSkill(plugin));
         registerSkillIfAbsent(registry, new HarvestRallySkill(plugin));
         registerSkillIfAbsent(registry, new TidalSurgeSkill(plugin));
+        registerSkillIfAbsent(registry, new LuckySpriteSummonSkill(plugin));
     }
 
     private void registerSkillIfAbsent(SkillRegistryService registry, Skill skill) {

--- a/src/main/java/com/x1f4r/mmocraft/demo/item/LuckyCharmTalisman.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/item/LuckyCharmTalisman.java
@@ -1,6 +1,7 @@
 package com.x1f4r.mmocraft.demo.item;
 
 import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.skill.LuckySpriteSummonSkill;
 import com.x1f4r.mmocraft.item.model.CustomItem;
 import com.x1f4r.mmocraft.item.model.ItemAbilityDescriptor;
 import com.x1f4r.mmocraft.item.model.ItemRarity;
@@ -17,8 +18,6 @@ import java.util.Map;
 public class LuckyCharmTalisman extends CustomItem {
 
     public static final String ITEM_ID = "lucky_charm_talisman";
-    private static final String PASSIVE_ABILITY_ID = "lucky_charm_passive";
-
     public LuckyCharmTalisman(MMOCraftPlugin plugin) {
         super(plugin);
     }
@@ -42,7 +41,7 @@ public class LuckyCharmTalisman extends CustomItem {
     public List<String> getLore() {
         return List.of(
                 "&7Carry in your inventory to boost rare drop luck.",
-                "&7Commission reward from lush farming islands."
+                "&7Right click to beckon a Lucky Sprite companion."
         );
     }
 
@@ -68,12 +67,12 @@ public class LuckyCharmTalisman extends CustomItem {
     @Override
     public List<ItemAbilityDescriptor> getAbilityDescriptors() {
         return List.of(new ItemAbilityDescriptor(
-                PASSIVE_ABILITY_ID,
-                "Fortune's Favor",
-                "Passive",
-                "Passively increases your chance to find valuable loot.",
-                0.0,
-                0.0));
+                LuckySpriteSummonSkill.SKILL_ID,
+                LuckySpriteSummonSkill.DISPLAY_NAME,
+                "Right Click",
+                LuckySpriteSummonSkill.DESCRIPTION,
+                LuckySpriteSummonSkill.MANA_COST,
+                LuckySpriteSummonSkill.COOLDOWN_SECONDS));
     }
 
     @Override

--- a/src/main/java/com/x1f4r/mmocraft/demo/pet/DemoCompanionPets.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/pet/DemoCompanionPets.java
@@ -1,0 +1,34 @@
+package com.x1f4r.mmocraft.demo.pet;
+
+import com.x1f4r.mmocraft.pet.model.CompanionPetDefinition;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.entity.EntityType;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Static helper for demo companion pet definitions.
+ */
+public final class DemoCompanionPets {
+
+    public static final String LUCKY_SPRITE_ID = "lucky_sprite";
+
+    private DemoCompanionPets() {
+    }
+
+    public static CompanionPetDefinition luckySprite() {
+        Map<Stat, Double> bonuses = new EnumMap<>(Stat.class);
+        bonuses.put(Stat.MAGIC_FIND, 30.0);
+        bonuses.put(Stat.PET_LUCK, 60.0);
+        bonuses.put(Stat.MANA_REGEN, 5.0);
+        return new CompanionPetDefinition(
+                LUCKY_SPRITE_ID,
+                "&dLucky Sprite",
+                EntityType.ALLAY,
+                bonuses,
+                true
+        );
+    }
+}
+

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/BerserkerRageSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/BerserkerRageSkill.java
@@ -1,9 +1,11 @@
 package com.x1f4r.mmocraft.demo.skill;
 
 import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.statuseffect.BerserkerRageStatusEffect;
 import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
 import com.x1f4r.mmocraft.skill.model.Skill;
 import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.statuseffect.manager.StatusEffectManager;
 import com.x1f4r.mmocraft.util.StringUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -11,8 +13,6 @@ import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 
 /**
  * Frenzy window used by the Berserker Gauntlet.
@@ -21,10 +21,9 @@ public class BerserkerRageSkill extends Skill {
 
     public static final String SKILL_ID = "berserker_rage";
     public static final String DISPLAY_NAME = "Berserker Rage";
-    public static final String DESCRIPTION = "Enter a frenzied state increasing damage and swing speed.";
+    public static final String DESCRIPTION = "Enter a blood frenzy gaining massive melee bonuses, cleave, and lifesteal.";
     public static final double MANA_COST = 80.0;
     public static final double COOLDOWN_SECONDS = 25.0;
-    private static final int DURATION_SECONDS = 8;
 
     public BerserkerRageSkill(MMOCraftPlugin plugin) {
         super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
@@ -37,15 +36,19 @@ public class BerserkerRageSkill extends Skill {
             return;
         }
 
-        int ticks = DURATION_SECONDS * 20;
-        player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, ticks, 1, false, false, true));
-        player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, ticks, 1, false, false, true));
+        StatusEffectManager manager = plugin.getStatusEffectManager();
+        if (manager == null) {
+            player.sendMessage(StringUtil.colorize("&cStatus effects are unavailable right now."));
+            return;
+        }
+
+        manager.applyEffect(player, new BerserkerRageStatusEffect(plugin, player.getUniqueId()));
 
         Location location = player.getLocation();
-        player.getWorld().spawnParticle(Particle.CRIT, location, 50, 0.8, 0.4, 0.8, 0.05);
-        player.getWorld().playSound(location, Sound.ENTITY_PLAYER_ATTACK_SWEEP, 1.0f, 0.8f);
+        player.getWorld().spawnParticle(Particle.EXPLOSION_EMITTER, location, 1);
+        player.getWorld().playSound(location, Sound.ENTITY_PLAYER_ATTACK_SWEEP, 1.0f, 0.6f);
 
-        player.sendMessage(StringUtil.colorize("&cBloodlust surges through your veins!"));
+        player.sendMessage(StringUtil.colorize("&4<< &cBloodlust surges through your veins! &4>>"));
         applyManaCost(casterProfile);
     }
 }

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/GaleForceDashSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/GaleForceDashSkill.java
@@ -1,7 +1,11 @@
 package com.x1f4r.mmocraft.demo.skill;
 
 import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.combat.model.DamageInstance;
+import com.x1f4r.mmocraft.combat.model.DamageType;
+import com.x1f4r.mmocraft.combat.service.DamageCalculationService;
 import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
 import com.x1f4r.mmocraft.skill.model.Skill;
 import com.x1f4r.mmocraft.skill.model.SkillType;
 import com.x1f4r.mmocraft.util.StringUtil;
@@ -10,9 +14,11 @@ import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
 
 /**
  * Movement burst used by the Windrunner Boots.
@@ -25,6 +31,8 @@ public class GaleForceDashSkill extends Skill {
     public static final double MANA_COST = 60.0;
     public static final double COOLDOWN_SECONDS = 15.0;
     private static final int DURATION_SECONDS = 6;
+    private static final double DASH_DISTANCE = 7.0;
+    private static final double COLLISION_RADIUS = 1.5;
 
     public GaleForceDashSkill(MMOCraftPlugin plugin) {
         super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
@@ -37,15 +45,83 @@ public class GaleForceDashSkill extends Skill {
             return;
         }
 
+        Location start = player.getLocation();
+        Vector direction = start.getDirection().setY(0).normalize();
+        if (direction.lengthSquared() < 0.0001) {
+            direction = new Vector(0, 0, 1);
+        }
+
+        Vector dashVelocity = direction.clone().multiply(1.6).setY(0.25);
+        player.setVelocity(dashVelocity);
+
         int ticks = DURATION_SECONDS * 20;
         player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, ticks, 2, false, false, true));
         player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP_BOOST, ticks, 1, false, false, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW_FALLING, 60, 0, false, false, true));
 
-        Location location = player.getLocation();
-        player.getWorld().spawnParticle(Particle.CLOUD, location, 40, 0.6, 0.2, 0.6, 0.02);
-        player.getWorld().playSound(location, Sound.ENTITY_PHANTOM_FLAP, 1.0f, 1.2f);
+        spawnDashParticles(player, start, direction);
+        handleDashCollisions(player, casterProfile, start, direction);
+
+        player.getWorld().playSound(start, Sound.ENTITY_PHANTOM_FLAP, 1.0f, 1.2f);
+        player.getWorld().playSound(start, Sound.ITEM_TRIDENT_RIPTIDE_2, 0.8f, 1.3f);
 
         player.sendMessage(StringUtil.colorize("&bWind surges around you, accelerating your stride."));
         applyManaCost(casterProfile);
+    }
+
+    private void spawnDashParticles(Player player, Location start, Vector direction) {
+        Location step = start.clone();
+        for (int i = 0; i < 12; i++) {
+            player.getWorld().spawnParticle(Particle.CLOUD, step, 6, 0.2, 0.05, 0.2, 0.01);
+            player.getWorld().spawnParticle(Particle.SWEEP_ATTACK, step, 1, 0.1, 0.05, 0.1, 0.0);
+            step.add(direction.clone().multiply(DASH_DISTANCE / 12.0));
+        }
+    }
+
+    private void handleDashCollisions(Player player, PlayerProfile profile, Location start, Vector direction) {
+        DamageCalculationService damageService = plugin.getDamageCalculationService();
+        Location end = start.clone().add(direction.clone().multiply(DASH_DISTANCE));
+        double baseDamage = 28.0
+                + profile.getStatValue(Stat.SPEED) * 0.35
+                + profile.getStatValue(Stat.STRENGTH) * 0.25;
+
+        for (Entity entity : player.getWorld().getNearbyEntities(start, DASH_DISTANCE, 2.5, DASH_DISTANCE)) {
+            if (!(entity instanceof LivingEntity living) || living.equals(player)) {
+                continue;
+            }
+            if (!isWithinDashPath(living.getLocation(), start, direction, DASH_DISTANCE)) {
+                continue;
+            }
+
+            double travel = living.getLocation().toVector().subtract(start.toVector()).dot(direction);
+            double damageMultiplier = 0.8 + Math.min(1.0, travel / DASH_DISTANCE) * 0.4;
+            double attackDamage = Math.max(0.0, baseDamage * damageMultiplier);
+
+            if (damageService != null) {
+                DamageInstance instance = damageService.calculateDamage(player, living, attackDamage, DamageType.PHYSICAL);
+                if (instance.finalDamage() > 0) {
+                    living.damage(instance.finalDamage(), player);
+                }
+            } else {
+                living.damage(attackDamage, player);
+            }
+
+            Vector knockback = direction.clone().multiply(0.9).setY(0.4);
+            living.setVelocity(living.getVelocity().add(knockback));
+            living.getWorld().spawnParticle(Particle.CLOUD, living.getLocation(), 12, 0.3, 0.2, 0.3, 0.02);
+        }
+
+        player.getWorld().spawnParticle(Particle.END_ROD, end, 12, 0.4, 0.2, 0.4, 0.01);
+    }
+
+    private boolean isWithinDashPath(Location entityLocation, Location start, Vector direction, double dashLength) {
+        Vector relative = entityLocation.toVector().subtract(start.toVector());
+        double projection = relative.dot(direction);
+        if (projection < 0 || projection > dashLength) {
+            return false;
+        }
+        Vector closestPoint = start.toVector().add(direction.clone().multiply(projection));
+        double lateralDistance = entityLocation.toVector().distance(closestPoint);
+        return lateralDistance <= COLLISION_RADIUS;
     }
 }

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/InfernoBurstSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/InfernoBurstSkill.java
@@ -1,6 +1,9 @@
 package com.x1f4r.mmocraft.demo.skill;
 
 import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.combat.model.DamageInstance;
+import com.x1f4r.mmocraft.combat.model.DamageType;
+import com.x1f4r.mmocraft.combat.service.DamageCalculationService;
 import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
 import com.x1f4r.mmocraft.playerdata.model.Stat;
 import com.x1f4r.mmocraft.skill.model.Skill;
@@ -14,6 +17,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
 
 /**
  * High impact AOE ability used by the Blazing Ember Rod.
@@ -28,8 +32,9 @@ public class InfernoBurstSkill extends Skill {
     private static final double BASE_DAMAGE = 60.0;
     private static final double INT_SCALING = 0.6;
     private static final double ABILITY_POWER_SCALING = 0.9;
-    private static final double EFFECT_RADIUS = 5.0;
-    private static final int FIRE_TICKS = 100;
+    private static final double EFFECT_RADIUS = 6.5;
+    private static final int FIRE_TICKS = 120;
+    private static final double CONE_DOT_THRESHOLD = 0.55; // ~56 degree cone
 
     public InfernoBurstSkill(MMOCraftPlugin plugin) {
         super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_AOE_POINT);
@@ -42,28 +47,55 @@ public class InfernoBurstSkill extends Skill {
             return;
         }
 
-        Location center = targetLocation != null ? targetLocation.clone() : caster.getLocation();
+        Location origin = caster.getLocation();
+        Vector facing = origin.getDirection().normalize();
+        Location castCenter = origin.clone().add(facing.clone().multiply(2));
+        Location center = targetLocation != null ? targetLocation.clone() : castCenter;
         World world = center.getWorld();
         if (world == null) {
             return;
         }
 
-        double damage = BASE_DAMAGE
+        DamageCalculationService damageService = plugin.getDamageCalculationService();
+        double baseDamage = BASE_DAMAGE
                 + casterProfile.getStatValue(Stat.INTELLIGENCE) * INT_SCALING
                 + casterProfile.getStatValue(Stat.ABILITY_POWER) * ABILITY_POWER_SCALING;
-        damage = Math.max(0.0, damage);
+        baseDamage = Math.max(0.0, baseDamage);
 
         for (Entity entity : world.getNearbyEntities(center, EFFECT_RADIUS, EFFECT_RADIUS, EFFECT_RADIUS)) {
             if (!(entity instanceof LivingEntity living) || entity.equals(caster)) {
                 continue;
             }
-            living.damage(damage, caster);
+            Vector toEntity = living.getLocation().toVector().subtract(origin.toVector());
+            double distance = toEntity.length();
+            if (distance == 0) {
+                distance = 0.001;
+            }
+            Vector direction = toEntity.clone().normalize();
+            if (direction.dot(facing) < CONE_DOT_THRESHOLD) {
+                continue; // Outside cone
+            }
+
+            double distanceMultiplier = 1.0 - Math.min(1.0, distance / EFFECT_RADIUS) * 0.5;
+            double finalBaseDamage = baseDamage * (0.75 + distanceMultiplier);
+
+            if (damageService != null) {
+                DamageInstance instance = damageService.calculateDamage(caster, living, finalBaseDamage, DamageType.MAGICAL);
+                if (instance.finalDamage() > 0) {
+                    living.damage(instance.finalDamage(), caster);
+                }
+            } else {
+                living.damage(finalBaseDamage, caster);
+            }
             living.setFireTicks(FIRE_TICKS);
         }
 
-        world.spawnParticle(Particle.FLAME, center, 80, 1.25, 0.5, 1.25, 0.05);
-        world.spawnParticle(Particle.LARGE_SMOKE, center, 40, 1.25, 0.5, 1.25, 0.01);
-        world.playSound(center, Sound.ITEM_FIRECHARGE_USE, 1.0f, 0.75f);
+        world.spawnParticle(Particle.FLAME, origin, 40, 0.3, 0.1, 0.3, 0.04);
+        world.spawnParticle(Particle.FLAME, center, 90, 1.6, 0.6, 1.6, 0.05);
+        world.spawnParticle(Particle.SMALL_FLAME, center, 40, 1.4, 0.4, 1.4, 0.03);
+        world.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, center, 25, 1.2, 0.3, 1.2, 0.02);
+        world.playSound(center, Sound.ITEM_FIRECHARGE_USE, 1.0f, 0.7f);
+        world.playSound(center, Sound.ENTITY_BLAZE_SHOOT, 0.7f, 1.4f);
 
         caster.sendMessage(StringUtil.colorize("&6You unleash an inferno of flames!"));
         applyManaCost(casterProfile);

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/LuckySpriteSummonSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/LuckySpriteSummonSkill.java
@@ -1,0 +1,104 @@
+package com.x1f4r.mmocraft.demo.skill;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.pet.DemoCompanionPets;
+import com.x1f4r.mmocraft.pet.model.ActiveCompanionPet;
+import com.x1f4r.mmocraft.pet.model.CompanionPetDefinition;
+import com.x1f4r.mmocraft.pet.service.CompanionPetService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Toggle skill that summons or dismisses the Lucky Sprite companion.
+ */
+public class LuckySpriteSummonSkill extends Skill {
+
+    public static final String SKILL_ID = "lucky_sprite_summon";
+    public static final String DISPLAY_NAME = "Lucky Sprite";
+    public static final String DESCRIPTION = "Summon a sprite companion that grants pet luck and looting bonuses.";
+    public static final double MANA_COST = 45.0;
+    public static final double COOLDOWN_SECONDS = 12.0;
+
+    private final CompanionPetDefinition companionDefinition = DemoCompanionPets.luckySprite();
+
+    public LuckySpriteSummonSkill(MMOCraftPlugin plugin) {
+        super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
+    }
+
+    @Override
+    public boolean canUse(PlayerProfile casterProfile) {
+        CompanionPetService service = plugin.getCompanionPetService();
+        if (service != null) {
+            Optional<ActiveCompanionPet> active = service.getActivePet(casterProfile.getPlayerUUID());
+            if (active.isPresent() && DemoCompanionPets.LUCKY_SPRITE_ID.equals(active.get().definition().id())) {
+                return true; // Always allow dismissal even if on cooldown or out of mana
+            }
+        }
+        return super.canUse(casterProfile);
+    }
+
+    @Override
+    public void execute(PlayerProfile casterProfile, Entity targetEntity, Location targetLocation) {
+        Player player = Bukkit.getPlayer(casterProfile.getPlayerUUID());
+        if (player == null) {
+            return;
+        }
+        CompanionPetService service = plugin.getCompanionPetService();
+        if (service == null) {
+            player.sendMessage(StringUtil.colorize("&cCompanion service unavailable."));
+            return;
+        }
+
+        UUID playerId = player.getUniqueId();
+        Optional<ActiveCompanionPet> active = service.getActivePet(playerId);
+        if (active.isPresent() && DemoCompanionPets.LUCKY_SPRITE_ID.equals(active.get().definition().id())) {
+            service.dismissPet(player);
+            try {
+                playSoundSafely(player.getWorld(), player.getLocation(), Sound.ENTITY_ALLAY_ITEM_TAKEN, 0.7f, 1.4f);
+            } catch (ExceptionInInitializerError | NoClassDefFoundError ignored) {
+            }
+            player.sendMessage(StringUtil.colorize("&dYour Lucky Sprite twirls away."));
+            // Clear cooldown on next tick so players can resummon once ready.
+            plugin.getServer().getScheduler().runTask(plugin, () -> casterProfile.setSkillCooldown(getSkillId(), 0));
+            return;
+        }
+
+        long spentMana = applyManaCost(casterProfile);
+        if (spentMana <= 0 && MANA_COST > 0) {
+            // Mana was not consumed; likely due to configuration quirks. Abort to avoid free casts.
+            player.sendMessage(StringUtil.colorize("&cYou failed to channel the sprite's essence."));
+            return;
+        }
+
+        service.summonPet(player, companionDefinition);
+        Location location = player.getLocation().add(0, 1.1, 0);
+        World world = player.getWorld();
+        world.spawnParticle(Particle.END_ROD, location, 30, 0.4, 0.4, 0.4, 0.01);
+        try {
+            playSoundSafely(world, location, Sound.ENTITY_ALLAY_AMBIENT_WITHOUT_ITEM, 0.9f, 1.5f);
+        } catch (ExceptionInInitializerError | NoClassDefFoundError ignored) {
+        }
+        player.sendMessage(StringUtil.colorize("&dA Lucky Sprite pledges to follow you."));
+    }
+
+    private void playSoundSafely(World world, Location location, Sound sound, float volume, float pitch) {
+        try {
+            world.playSound(location, sound, volume, pitch);
+        } catch (ExceptionInInitializerError | NoClassDefFoundError ignored) {
+            // Environment without a fully initialised registry (e.g. unit tests).
+        }
+    }
+}
+

--- a/src/main/java/com/x1f4r/mmocraft/demo/skill/ProspectorPulseSkill.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/skill/ProspectorPulseSkill.java
@@ -5,6 +5,8 @@ import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
 import com.x1f4r.mmocraft.skill.model.Skill;
 import com.x1f4r.mmocraft.skill.model.SkillType;
 import com.x1f4r.mmocraft.util.StringUtil;
+import com.x1f4r.mmocraft.world.resourcegathering.model.ActiveResourceNode;
+import com.x1f4r.mmocraft.world.resourcegathering.service.ActiveNodeManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -25,6 +27,7 @@ public class ProspectorPulseSkill extends Skill {
     public static final double MANA_COST = 50.0;
     public static final double COOLDOWN_SECONDS = 24.0;
     private static final int DURATION_SECONDS = 10;
+    private static final double NODE_REVEAL_RADIUS = 18.0;
 
     public ProspectorPulseSkill(MMOCraftPlugin plugin) {
         super(plugin, SKILL_ID, DISPLAY_NAME, DESCRIPTION, MANA_COST, COOLDOWN_SECONDS, 0.0, SkillType.ACTIVE_SELF);
@@ -43,9 +46,44 @@ public class ProspectorPulseSkill extends Skill {
 
         Location location = player.getLocation();
         player.getWorld().spawnParticle(Particle.ENCHANTED_HIT, location, 60, 0.6, 0.4, 0.6, 0.1);
+        player.getWorld().spawnParticle(Particle.GLOW, location, 30, 0.4, 0.2, 0.4, 0.02);
         player.getWorld().playSound(location, Sound.BLOCK_AMETHYST_BLOCK_CHIME, 1.0f, 1.0f);
+
+        highlightNearbyNodes(player, location);
 
         player.sendMessage(StringUtil.colorize("&eYour drill hums with prospecting energy."));
         applyManaCost(casterProfile);
+    }
+
+    private void highlightNearbyNodes(Player player, Location origin) {
+        ActiveNodeManager nodeManager = plugin.getActiveNodeManager();
+        if (nodeManager == null) {
+            return;
+        }
+
+        int highlighted = 0;
+        for (ActiveResourceNode node : nodeManager.getAllActiveNodesView().values()) {
+            if (node.isDepleted() || node.getLocation().getWorld() == null) {
+                continue;
+            }
+            if (!node.getLocation().getWorld().equals(origin.getWorld())) {
+                continue;
+            }
+            if (node.getLocation().distanceSquared(origin) > NODE_REVEAL_RADIUS * NODE_REVEAL_RADIUS) {
+                continue;
+            }
+
+            Location nodeLocation = node.getLocation().clone().add(0.5, 0.5, 0.5);
+            player.getWorld().spawnParticle(Particle.HAPPY_VILLAGER, nodeLocation, 12, 0.25, 0.35, 0.25, 0.05);
+            player.getWorld().spawnParticle(Particle.CRIT, nodeLocation, 8, 0.2, 0.25, 0.2, 0.02);
+            player.getWorld().playSound(nodeLocation, Sound.BLOCK_AMETHYST_BLOCK_RESONATE, 0.6f, 1.5f);
+            highlighted++;
+        }
+
+        if (highlighted > 0) {
+            player.sendMessage(StringUtil.colorize("&aProspector pulse reveals &e" + highlighted + " &aminable nodes nearby."));
+        } else {
+            player.sendMessage(StringUtil.colorize("&7No rich veins resonate with your pulse."));
+        }
     }
 }

--- a/src/main/java/com/x1f4r/mmocraft/demo/statuseffect/BerserkerRageStatusEffect.java
+++ b/src/main/java/com/x1f4r/mmocraft/demo/statuseffect/BerserkerRageStatusEffect.java
@@ -1,0 +1,109 @@
+package com.x1f4r.mmocraft.demo.statuseffect;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.playerdata.runtime.PlayerRuntimeAttributeService;
+import com.x1f4r.mmocraft.statuseffect.model.StatusEffect;
+import com.x1f4r.mmocraft.statuseffect.model.StatusEffectType;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * High impact berserk buff triggered by the Berserker Gauntlet.
+ * Applies aggressive stat modifiers and visual flair while the effect lasts.
+ */
+public class BerserkerRageStatusEffect extends StatusEffect {
+
+    private static final double DURATION_SECONDS = 8.0;
+    private static final double TICK_INTERVAL_SECONDS = 1.0;
+    private static final String STAT_SOURCE_KEY = "status:berserker_rage";
+
+    private final Map<Stat, Double> statModifiers;
+
+    public BerserkerRageStatusEffect(MMOCraftPlugin plugin, UUID sourceEntityId) {
+        super(plugin, StatusEffectType.BERSERK, DURATION_SECONDS, 1.0, TICK_INTERVAL_SECONDS, sourceEntityId);
+        Map<Stat, Double> modifiers = new EnumMap<>(Stat.class);
+        modifiers.put(Stat.STRENGTH, 80.0);
+        modifiers.put(Stat.ATTACK_SPEED, 35.0);
+        modifiers.put(Stat.FEROCITY, 40.0);
+        modifiers.put(Stat.CRITICAL_DAMAGE, 25.0);
+        modifiers.put(Stat.DEFENSE, -20.0);
+        this.statModifiers = Map.copyOf(modifiers);
+    }
+
+    @Override
+    public void onApply(LivingEntity target, PlayerProfile targetProfileIfPlayer) {
+        if (!(target instanceof Player player)) {
+            return;
+        }
+        if (targetProfileIfPlayer != null) {
+            targetProfileIfPlayer.setTemporaryStatModifiers(STAT_SOURCE_KEY, statModifiers);
+            targetProfileIfPlayer.recalculateDerivedAttributes();
+            syncRuntimeAttributes(player, targetProfileIfPlayer);
+        }
+        Location location = player.getLocation();
+        World world = player.getWorld();
+        world.spawnParticle(Particle.CRIT, location, 40, 0.6, 0.4, 0.6, 0.2);
+        world.spawnParticle(Particle.LAVA, location, 15, 0.3, 0.2, 0.3, 0.05);
+        try {
+            playSoundSafely(world, location, Sound.ENTITY_WITHER_BREAK_BLOCK, 1.2f, 0.7f);
+        } catch (ExceptionInInitializerError | NoClassDefFoundError ignored) {
+        }
+        player.sendMessage(StringUtil.colorize("&cYou lose yourself to berserker fury!"));
+    }
+
+    @Override
+    public void onTick(LivingEntity target, PlayerProfile targetProfileIfPlayer) {
+        if (!(target instanceof Player player)) {
+            return;
+        }
+        Location location = player.getLocation();
+        player.getWorld().spawnParticle(Particle.SOUL_FIRE_FLAME, location.add(0, 0.2, 0), 20, 0.5, 0.3, 0.5, 0.02);
+        player.getWorld().spawnParticle(Particle.SWEEP_ATTACK, location, 6, 0.2, 0.1, 0.2, 0.01);
+    }
+
+    @Override
+    public void onExpire(LivingEntity target, PlayerProfile targetProfileIfPlayer) {
+        if (!(target instanceof Player player)) {
+            return;
+        }
+        if (targetProfileIfPlayer != null) {
+            targetProfileIfPlayer.clearTemporaryStatModifiers(STAT_SOURCE_KEY);
+            targetProfileIfPlayer.recalculateDerivedAttributes();
+            syncRuntimeAttributes(player, targetProfileIfPlayer);
+        }
+        try {
+            playSoundSafely(player.getWorld(), player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 1.0f, 1.3f);
+        } catch (ExceptionInInitializerError | NoClassDefFoundError ignored) {
+        }
+        player.sendMessage(StringUtil.colorize("&7Your berserker trance fades."));
+    }
+
+    private void syncRuntimeAttributes(Player player, PlayerProfile profile) {
+        Objects.requireNonNull(profile, "profile");
+        PlayerRuntimeAttributeService runtimeService = plugin.getPlayerRuntimeAttributeService();
+        if (runtimeService != null) {
+            runtimeService.syncPlayer(player);
+        }
+    }
+
+    private void playSoundSafely(World world, Location location, Sound sound, float volume, float pitch) {
+        try {
+            world.playSound(location, sound, volume, pitch);
+        } catch (ExceptionInInitializerError | NoClassDefFoundError ignored) {
+            // ignore if registry not available (e.g. during unit tests)
+        }
+    }
+}
+

--- a/src/main/java/com/x1f4r/mmocraft/item/listeners/CustomItemAbilityListener.java
+++ b/src/main/java/com/x1f4r/mmocraft/item/listeners/CustomItemAbilityListener.java
@@ -1,0 +1,166 @@
+package com.x1f4r.mmocraft.item.listeners;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.item.api.NBTUtil;
+import com.x1f4r.mmocraft.item.model.CustomItem;
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.skill.model.Skill;
+import com.x1f4r.mmocraft.skill.model.SkillType;
+import com.x1f4r.mmocraft.skill.service.SkillRegistryService;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import com.x1f4r.mmocraft.util.StringUtil;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Allows custom items to trigger their associated skills when used.
+ */
+public class CustomItemAbilityListener implements Listener {
+
+    private final MMOCraftPlugin plugin;
+    private final SkillRegistryService skillRegistryService;
+    private final PlayerDataService playerDataService;
+    private final LoggingUtil logger;
+
+    public CustomItemAbilityListener(MMOCraftPlugin plugin) {
+        this.plugin = plugin;
+        this.skillRegistryService = plugin.getSkillRegistryService();
+        this.playerDataService = plugin.getPlayerDataService();
+        this.logger = plugin.getLoggingUtil();
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        ItemStack item = event.getItem();
+        Location clickedLocation = event.getClickedBlock() != null ? event.getClickedBlock().getLocation() : null;
+        if (!triggerAbility(event.getPlayer(), item, null, clickedLocation)) {
+            return;
+        }
+        event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+        ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
+        if (item == null || item.getType().isAir()) {
+            return;
+        }
+        if (triggerAbility(event.getPlayer(), item, event.getRightClicked(), event.getRightClicked().getLocation())) {
+            event.setCancelled(true);
+        }
+    }
+
+    private boolean triggerAbility(Player player, ItemStack item, Entity explicitTarget, Location explicitLocation) {
+        if (item == null || item.getType().isAir()) {
+            return false;
+        }
+        String abilityIds = NBTUtil.getString(item, CustomItem.CUSTOM_ITEM_ABILITY_IDS_NBT_KEY, plugin);
+        if (abilityIds == null || abilityIds.isBlank()) {
+            return false;
+        }
+        PlayerProfile profile = playerDataService.getPlayerProfile(player.getUniqueId());
+        if (profile == null) {
+            player.sendMessage(StringUtil.colorize("&cYour profile data is still loading."));
+            return false;
+        }
+        return Arrays.stream(abilityIds.split(","))
+                .map(String::trim)
+                .filter(id -> !id.isEmpty())
+                .anyMatch(id -> castAbility(player, profile, id, explicitTarget, explicitLocation));
+    }
+
+    private boolean castAbility(Player player, PlayerProfile profile, String abilityId, Entity explicitTarget, Location explicitLocation) {
+        Optional<Skill> optionalSkill = skillRegistryService.getSkill(abilityId);
+        if (optionalSkill.isEmpty()) {
+            return false;
+        }
+        Skill skill = optionalSkill.get();
+        if (!skill.canUse(profile)) {
+            if (profile.isSkillOnCooldown(skill.getSkillId())) {
+                double seconds = profile.getSkillRemainingCooldown(skill.getSkillId()) / 1000.0;
+                player.sendMessage(StringUtil.colorize("&c" + skill.getSkillName() + " is on cooldown for " + String.format("%.1f", seconds) + "s."));
+            } else if (profile.getCurrentMana() < Math.ceil(skill.getEffectiveManaCost(profile))) {
+                player.sendMessage(StringUtil.colorize("&cNot enough mana for " + skill.getSkillName() + "."));
+            }
+            return false;
+        }
+
+        Entity targetEntity = resolveTargetEntity(player, skill, explicitTarget);
+        if (skill.getSkillType() == SkillType.ACTIVE_TARGETED_ENTITY) {
+            if (!(targetEntity instanceof LivingEntity)) {
+                player.sendMessage(StringUtil.colorize("&cNo valid target in sight for " + skill.getSkillName() + "."));
+                return false;
+            }
+        }
+
+        Location targetLocation = resolveLocation(player, skill, explicitLocation);
+
+        try {
+            skill.execute(profile, targetEntity, targetLocation);
+            skill.onCooldown(profile);
+            player.sendActionBar(StringUtil.colorize("&b» " + skill.getSkillName()));
+            return true;
+        } catch (Exception ex) {
+            logger.severe("Error executing item ability '" + abilityId + "' for " + player.getName() + ": " + ex.getMessage(), ex);
+            player.sendMessage(StringUtil.colorize("&cSomething went wrong while using that ability."));
+            return false;
+        }
+    }
+
+    private Entity resolveTargetEntity(Player player, Skill skill, Entity explicitTarget) {
+        if (skill.getSkillType() != SkillType.ACTIVE_TARGETED_ENTITY) {
+            return null;
+        }
+        if (explicitTarget != null) {
+            return explicitTarget;
+        }
+        try {
+            return player.getTargetEntity(12);
+        } catch (NoSuchMethodError ignored) {
+            // API fallback: use ray trace if running on an older server version
+            return player.getNearbyEntities(12, 12, 12).stream()
+                    .filter(LivingEntity.class::isInstance)
+                    .findFirst()
+                    .orElse(null);
+        }
+    }
+
+    private Location resolveLocation(Player player, Skill skill, Location explicitLocation) {
+        if (skill.getSkillType() == SkillType.ACTIVE_AOE_POINT) {
+            if (explicitLocation != null) {
+                return explicitLocation.clone();
+            }
+            Block targetBlock = player.getTargetBlockExact(20);
+            if (targetBlock != null) {
+                return targetBlock.getLocation();
+            }
+            return player.getLocation();
+        }
+        return explicitLocation;
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/pet/listeners/CompanionPetListener.java
+++ b/src/main/java/com/x1f4r/mmocraft/pet/listeners/CompanionPetListener.java
@@ -1,0 +1,36 @@
+package com.x1f4r.mmocraft.pet.listeners;
+
+import com.x1f4r.mmocraft.pet.service.CompanionPetService;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.Objects;
+
+/**
+ * Keeps companion pets in sync with player lifecycle events.
+ */
+public class CompanionPetListener implements Listener {
+
+    private final CompanionPetService companionPetService;
+    private final LoggingUtil logger;
+
+    public CompanionPetListener(CompanionPetService companionPetService, LoggingUtil logger) {
+        this.companionPetService = Objects.requireNonNull(companionPetService, "companionPetService");
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        companionPetService.handlePlayerQuit(event.getPlayer().getUniqueId());
+        logger.finer("Dismissed companion pet for quitting player " + event.getPlayer().getName());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        companionPetService.handlePlayerDeath(event.getEntity().getUniqueId());
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/pet/model/ActiveCompanionPet.java
+++ b/src/main/java/com/x1f4r/mmocraft/pet/model/ActiveCompanionPet.java
@@ -1,0 +1,11 @@
+package com.x1f4r.mmocraft.pet.model;
+
+import org.bukkit.entity.LivingEntity;
+
+import java.util.UUID;
+
+/**
+ * Runtime association between a player and their active companion pet.
+ */
+public record ActiveCompanionPet(UUID ownerId, LivingEntity entity, CompanionPetDefinition definition, String statSourceKey) {
+}

--- a/src/main/java/com/x1f4r/mmocraft/pet/model/CompanionPetDefinition.java
+++ b/src/main/java/com/x1f4r/mmocraft/pet/model/CompanionPetDefinition.java
@@ -1,0 +1,43 @@
+package com.x1f4r.mmocraft.pet.model;
+
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import org.bukkit.entity.EntityType;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Configuration describing a summonable companion pet.
+ */
+public record CompanionPetDefinition(String id,
+                                     String displayName,
+                                     EntityType entityType,
+                                     Map<Stat, Double> statBonuses,
+                                     boolean invulnerable) {
+
+    public CompanionPetDefinition {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Pet id cannot be null or blank");
+        }
+        if (displayName == null || displayName.isBlank()) {
+            throw new IllegalArgumentException("Pet display name cannot be null or blank");
+        }
+        if (entityType == null) {
+            throw new IllegalArgumentException("Pet entity type cannot be null");
+        }
+    }
+
+    public Map<Stat, Double> statBonuses() {
+        if (statBonuses == null || statBonuses.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<Stat, Double> copy = new EnumMap<>(Stat.class);
+        statBonuses.forEach((stat, value) -> {
+            if (stat != null && value != null && value != 0.0) {
+                copy.put(stat, value);
+            }
+        });
+        return Collections.unmodifiableMap(copy);
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/pet/service/BasicCompanionPetService.java
+++ b/src/main/java/com/x1f4r/mmocraft/pet/service/BasicCompanionPetService.java
@@ -1,0 +1,203 @@
+package com.x1f4r.mmocraft.pet.service;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.pet.model.ActiveCompanionPet;
+import com.x1f4r.mmocraft.pet.model.CompanionPetDefinition;
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.runtime.PlayerRuntimeAttributeService;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import com.x1f4r.mmocraft.util.StringUtil;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Tameable;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.util.Vector;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default in-memory implementation of {@link CompanionPetService}.
+ */
+public class BasicCompanionPetService implements CompanionPetService {
+
+    private static final String STAT_SOURCE_PREFIX = "pet:";
+    private static final String METADATA_KEY = "MMOCRAFT_COMPANION";
+
+    private final MMOCraftPlugin plugin;
+    private final PlayerDataService playerDataService;
+    private final PlayerRuntimeAttributeService runtimeAttributeService;
+    private final LoggingUtil logger;
+    private final Map<UUID, ActiveCompanionPet> activePets = new ConcurrentHashMap<>();
+
+    public BasicCompanionPetService(MMOCraftPlugin plugin,
+                                    PlayerDataService playerDataService,
+                                    PlayerRuntimeAttributeService runtimeAttributeService,
+                                    LoggingUtil logger) {
+        this.plugin = plugin;
+        this.playerDataService = playerDataService;
+        this.runtimeAttributeService = runtimeAttributeService;
+        this.logger = logger;
+    }
+
+    @Override
+    public void summonPet(Player player, CompanionPetDefinition definition) {
+        if (player == null || definition == null) {
+            return;
+        }
+        dismissPet(player);
+        PlayerProfile profile = playerDataService.getPlayerProfile(player.getUniqueId());
+        if (profile == null) {
+            player.sendMessage(StringUtil.colorize("&cUnable to summon a pet while your profile is loading."));
+            return;
+        }
+        LivingEntity entity = spawnPetEntity(player, definition);
+        if (entity == null) {
+            player.sendMessage(StringUtil.colorize("&cFailed to summon your companion."));
+            return;
+        }
+        String statSourceKey = STAT_SOURCE_PREFIX + definition.id();
+        applyStatBonuses(profile, definition.statBonuses(), statSourceKey);
+        runtimeAttributeService.syncPlayer(player);
+        activePets.put(player.getUniqueId(), new ActiveCompanionPet(player.getUniqueId(), entity, definition, statSourceKey));
+        player.sendMessage(StringUtil.colorize("&a" + definition.displayName() + " answers your call."));
+    }
+
+    @Override
+    public void dismissPet(Player player) {
+        if (player == null) {
+            return;
+        }
+        dismissPet(player.getUniqueId());
+    }
+
+    @Override
+    public void dismissPet(UUID playerId) {
+        if (playerId == null) {
+            return;
+        }
+        ActiveCompanionPet active = activePets.remove(playerId);
+        if (active == null) {
+            return;
+        }
+        Entity entity = active.entity();
+        if (entity != null && entity.isValid()) {
+            entity.remove();
+        }
+        PlayerProfile profile = playerDataService.getPlayerProfile(playerId);
+        if (profile != null) {
+            profile.clearTemporaryStatModifiers(active.statSourceKey());
+            Player owner = Bukkit.getPlayer(playerId);
+            if (owner != null && owner.isOnline()) {
+                runtimeAttributeService.syncPlayer(owner);
+            }
+        }
+    }
+
+    @Override
+    public Optional<ActiveCompanionPet> getActivePet(UUID playerId) {
+        return Optional.ofNullable(activePets.get(playerId));
+    }
+
+    @Override
+    public void tick() {
+        for (ActiveCompanionPet active : activePets.values()) {
+            Player owner = Bukkit.getPlayer(active.ownerId());
+            if (owner == null || !owner.isOnline()) {
+                dismissPet(active.ownerId());
+                continue;
+            }
+            LivingEntity pet = active.entity();
+            if (pet == null || pet.isDead()) {
+                dismissPet(active.ownerId());
+                continue;
+            }
+            keepPetNearOwner(owner, pet);
+        }
+    }
+
+    private void keepPetNearOwner(Player owner, LivingEntity pet) {
+        Location ownerLocation = owner.getLocation();
+        double distanceSquared = pet.getLocation().distanceSquared(ownerLocation);
+        if (distanceSquared > 100) {
+            pet.teleport(ownerLocation.add(0.5, 0, 0.5));
+            return;
+        }
+        if (distanceSquared > 16) {
+            Vector direction = ownerLocation.toVector().subtract(pet.getLocation().toVector()).normalize().multiply(0.35);
+            pet.setVelocity(direction);
+        }
+    }
+
+    private LivingEntity spawnPetEntity(Player owner, CompanionPetDefinition definition) {
+        Location spawnLocation = owner.getLocation().clone().add(owner.getLocation().getDirection().normalize().multiply(0.8));
+        LivingEntity entity;
+        try {
+            entity = (LivingEntity) owner.getWorld().spawnEntity(spawnLocation, definition.entityType());
+        } catch (Exception ex) {
+            logger.severe("Failed to spawn companion entity of type " + definition.entityType() + ": " + ex.getMessage(), ex);
+            return null;
+        }
+        entity.setCustomNameVisible(true);
+        entity.customName(LegacyComponentSerializer.legacyAmpersand().deserialize(definition.displayName()));
+        entity.setPersistent(false);
+        entity.setRemoveWhenFarAway(false);
+        entity.setAI(true);
+        entity.setMetadata(METADATA_KEY, new FixedMetadataValue(plugin, true));
+        if (definition.invulnerable()) {
+            entity.setInvulnerable(true);
+            AttributeInstance maxHealth = entity.getAttribute(Attribute.MAX_HEALTH);
+            if (maxHealth != null) {
+                maxHealth.setBaseValue(Math.max(maxHealth.getBaseValue(), 40.0));
+                entity.setHealth(maxHealth.getValue());
+            }
+        }
+        if (entity instanceof Tameable tameable) {
+            tameable.setTamed(true);
+            tameable.setOwner(owner);
+        }
+        return entity;
+    }
+
+    private void applyStatBonuses(PlayerProfile profile, Map<Stat, Double> bonuses, String sourceKey) {
+        if (bonuses == null || bonuses.isEmpty()) {
+            profile.clearTemporaryStatModifiers(sourceKey);
+            return;
+        }
+        Map<Stat, Double> copy = new EnumMap<>(Stat.class);
+        bonuses.forEach((stat, value) -> {
+            if (stat != null && value != null && value != 0.0) {
+                copy.put(stat, value);
+            }
+        });
+        profile.setTemporaryStatModifiers(sourceKey, copy);
+    }
+
+    @Override
+    public void handlePlayerQuit(UUID playerId) {
+        dismissPet(playerId);
+    }
+
+    @Override
+    public void handlePlayerDeath(UUID playerId) {
+        dismissPet(playerId);
+    }
+
+    @Override
+    public void shutdown() {
+        activePets.keySet().forEach(this::dismissPet);
+        activePets.clear();
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/pet/service/CompanionPetService.java
+++ b/src/main/java/com/x1f4r/mmocraft/pet/service/CompanionPetService.java
@@ -1,0 +1,30 @@
+package com.x1f4r.mmocraft.pet.service;
+
+import com.x1f4r.mmocraft.pet.model.ActiveCompanionPet;
+import com.x1f4r.mmocraft.pet.model.CompanionPetDefinition;
+import org.bukkit.entity.Player;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Manages lifecycle of companion pets bound to players.
+ */
+public interface CompanionPetService {
+
+    void summonPet(Player player, CompanionPetDefinition definition);
+
+    void dismissPet(Player player);
+
+    void dismissPet(UUID playerId);
+
+    Optional<ActiveCompanionPet> getActivePet(UUID playerId);
+
+    void tick();
+
+    void handlePlayerQuit(UUID playerId);
+
+    void handlePlayerDeath(UUID playerId);
+
+    void shutdown();
+}

--- a/src/main/java/com/x1f4r/mmocraft/playerdata/hud/PlayerHudService.java
+++ b/src/main/java/com/x1f4r/mmocraft/playerdata/hud/PlayerHudService.java
@@ -1,0 +1,107 @@
+package com.x1f4r.mmocraft.playerdata.hud;
+
+import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Handles lightweight HUD updates such as health/mana action bars and passive mana regeneration.
+ */
+public class PlayerHudService {
+
+    private final PlayerDataService playerDataService;
+    private final LoggingUtil logger;
+    private final Map<UUID, Double> manaRemainder = new ConcurrentHashMap<>();
+
+    public PlayerHudService(PlayerDataService playerDataService, LoggingUtil logger) {
+        this.playerDataService = playerDataService;
+        this.logger = logger;
+    }
+
+    /**
+     * Updates all online players, regenerating mana and refreshing their action bar HUD.
+     *
+     * @param deltaSeconds time elapsed since the previous tick invocation.
+     */
+    public void tick(double deltaSeconds) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (!player.isOnline()) {
+                continue;
+            }
+            PlayerProfile profile = playerDataService.getPlayerProfile(player.getUniqueId());
+            if (profile == null) {
+                continue;
+            }
+            try {
+                regenerateMana(profile, deltaSeconds);
+                sendActionBar(player, profile);
+            } catch (Exception ex) {
+                logger.severe("Failed to update HUD for " + player.getName() + ": " + ex.getMessage(), ex);
+            }
+        }
+    }
+
+    private void regenerateMana(PlayerProfile profile, double deltaSeconds) {
+        long maxMana = Math.max(0L, profile.getMaxMana());
+        if (maxMana <= 0) {
+            manaRemainder.remove(profile.getPlayerUUID());
+            profile.setCurrentMana(0);
+            return;
+        }
+        if (profile.getCurrentMana() >= maxMana) {
+            manaRemainder.remove(profile.getPlayerUUID());
+            profile.setCurrentMana(Math.min(profile.getCurrentMana(), maxMana));
+            return;
+        }
+        double regenRate = Math.max(0.0, profile.getStatValue(Stat.MANA_REGEN));
+        double accumulated = manaRemainder.getOrDefault(profile.getPlayerUUID(), 0.0);
+        accumulated += regenRate * deltaSeconds;
+        long wholePoints = (long) Math.floor(accumulated);
+        if (wholePoints > 0) {
+            long newMana = Math.min(maxMana, profile.getCurrentMana() + wholePoints);
+            profile.setCurrentMana(newMana);
+            accumulated -= wholePoints;
+        }
+        manaRemainder.put(profile.getPlayerUUID(), accumulated);
+    }
+
+    private void sendActionBar(Player player, PlayerProfile profile) {
+        AttributeInstance healthAttribute = player.getAttribute(Attribute.MAX_HEALTH);
+        double maxHealth = healthAttribute != null ? healthAttribute.getValue() : profile.getMaxHealth();
+        double currentHealth = Math.min(player.getHealth(), maxHealth);
+
+        long currentMana = profile.getCurrentMana();
+        long maxMana = Math.max(1L, profile.getMaxMana());
+        double regenRate = Math.max(0.0, profile.getStatValue(Stat.MANA_REGEN));
+
+        String message = String.format(
+                "&c❤ %.0f/%.0f  &b✦ %d/%d  &3⇑ %.1f/s  &6Lvl %d",
+                currentHealth,
+                maxHealth,
+                currentMana,
+                maxMana,
+                regenRate,
+                profile.getLevel());
+        player.sendActionBar(LegacyComponentSerializer.legacyAmpersand().deserialize(message));
+    }
+
+    public void clearCache(UUID playerId) {
+        if (playerId != null) {
+            manaRemainder.remove(playerId);
+        }
+    }
+
+    public void clearAll() {
+        manaRemainder.clear();
+    }
+}

--- a/src/main/java/com/x1f4r/mmocraft/playerdata/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/x1f4r/mmocraft/playerdata/listeners/PlayerJoinQuitListener.java
@@ -1,6 +1,7 @@
 package com.x1f4r.mmocraft.playerdata.listeners;
 
 import com.x1f4r.mmocraft.playerdata.PlayerDataService;
+import com.x1f4r.mmocraft.playerdata.hud.PlayerHudService;
 import com.x1f4r.mmocraft.util.LoggingUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -14,10 +15,16 @@ public class PlayerJoinQuitListener implements Listener {
 
     private final PlayerDataService playerDataService;
     private final LoggingUtil logger;
+    private final PlayerHudService playerHudService;
 
     public PlayerJoinQuitListener(PlayerDataService playerDataService, LoggingUtil logger) {
+        this(playerDataService, logger, null);
+    }
+
+    public PlayerJoinQuitListener(PlayerDataService playerDataService, LoggingUtil logger, PlayerHudService playerHudService) {
         this.playerDataService = playerDataService;
         this.logger = logger;
+        this.playerHudService = playerHudService;
         logger.debug("PlayerJoinQuitListener initialized.");
     }
 
@@ -93,6 +100,9 @@ public class PlayerJoinQuitListener implements Listener {
             .thenRun(() -> {
                 logger.info("Profile saved successfully for " + player.getName() + " on quit.");
                 playerDataService.uncachePlayerProfile(player.getUniqueId());
+                if (playerHudService != null) {
+                    playerHudService.clearCache(player.getUniqueId());
+                }
             })
             .exceptionally(ex -> {
                 logger.severe("Failed to save profile for " + player.getName() + " on quit: " + ex.getMessage(), ex);
@@ -100,6 +110,9 @@ public class PlayerJoinQuitListener implements Listener {
                 // Still uncache to prevent issues with stale data in memory if player rejoins quickly? Or keep to retry save?
                 // For now, let's still uncache.
                 playerDataService.uncachePlayerProfile(player.getUniqueId());
+                if (playerHudService != null) {
+                    playerHudService.clearCache(player.getUniqueId());
+                }
                 return null;
             });
     }

--- a/src/main/java/com/x1f4r/mmocraft/world/spawning/listeners/MobNameplateListener.java
+++ b/src/main/java/com/x1f4r/mmocraft/world/spawning/listeners/MobNameplateListener.java
@@ -1,0 +1,71 @@
+package com.x1f4r.mmocraft.world.spawning.listeners;
+
+import com.x1f4r.mmocraft.combat.service.MobStatProvider;
+import com.x1f4r.mmocraft.util.LoggingUtil;
+import com.x1f4r.mmocraft.world.spawning.service.BasicCustomSpawningService;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Applies ambient name tags and stat hints to naturally spawned mobs.
+ */
+public class MobNameplateListener implements Listener {
+
+    private final MobStatProvider mobStatProvider;
+    private final LoggingUtil logger;
+
+    public MobNameplateListener(MobStatProvider mobStatProvider,
+                                LoggingUtil logger) {
+        this.mobStatProvider = Objects.requireNonNull(mobStatProvider);
+        this.logger = Objects.requireNonNull(logger);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCreatureSpawn(CreatureSpawnEvent event) {
+        LivingEntity entity = event.getEntity();
+        if (entity.getCustomName() != null) {
+            return; // Already custom-named
+        }
+        if (entity.hasMetadata(BasicCustomSpawningService.METADATA_KEY_CUSTOM_MOB_ID)) {
+            return; // Managed by custom spawn system
+        }
+        double baseHealth = mobStatProvider.getBaseHealth(entity.getType());
+        double baseDamage = mobStatProvider.getBaseAttackDamage(entity.getType());
+        if (baseHealth <= 0 && baseDamage <= 0) {
+            return;
+        }
+        int suggestedLevel = Math.max(1, (int) Math.round(baseHealth / 20.0));
+        String colour = entity instanceof Monster ? "&c" : "&a";
+        String name = String.format("%s[Lv. %d] &f%s &c❤%.0f &7⚔%.1f",
+                colour,
+                suggestedLevel,
+                formatEntityName(entity.getType()),
+                baseHealth,
+                baseDamage);
+        entity.customName(LegacyComponentSerializer.legacyAmpersand().deserialize(name));
+        entity.setCustomNameVisible(true);
+        logger.finest("Applied nameplate to " + entity.getType() + " at " + entity.getLocation());
+    }
+
+    private String formatEntityName(EntityType type) {
+        String raw = type.name().toLowerCase(Locale.ROOT).replace('_', ' ');
+        String[] parts = raw.split(" ");
+        StringBuilder builder = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            builder.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1)).append(' ');
+        }
+        return builder.toString().trim();
+    }
+}

--- a/src/test/java/com/x1f4r/mmocraft/demo/DemoContentModuleShowcaseTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/demo/DemoContentModuleShowcaseTest.java
@@ -17,6 +17,7 @@ import com.x1f4r.mmocraft.demo.skill.BerserkerRageSkill;
 import com.x1f4r.mmocraft.demo.skill.GaleForceDashSkill;
 import com.x1f4r.mmocraft.demo.skill.HarvestRallySkill;
 import com.x1f4r.mmocraft.demo.skill.InfernoBurstSkill;
+import com.x1f4r.mmocraft.demo.skill.LuckySpriteSummonSkill;
 import com.x1f4r.mmocraft.demo.skill.ProspectorPulseSkill;
 import com.x1f4r.mmocraft.demo.skill.TidalSurgeSkill;
 import com.x1f4r.mmocraft.item.model.CustomItem;
@@ -182,6 +183,7 @@ class DemoContentModuleShowcaseTest {
                 GaleForceDashSkill.SKILL_ID,
                 BerserkerRageSkill.SKILL_ID,
                 ProspectorPulseSkill.SKILL_ID,
+                LuckySpriteSummonSkill.SKILL_ID,
                 HarvestRallySkill.SKILL_ID,
                 TidalSurgeSkill.SKILL_ID
         );

--- a/src/test/java/com/x1f4r/mmocraft/demo/skill/LuckySpriteSummonSkillTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/demo/skill/LuckySpriteSummonSkillTest.java
@@ -1,0 +1,116 @@
+package com.x1f4r.mmocraft.demo.skill;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.demo.pet.DemoCompanionPets;
+import com.x1f4r.mmocraft.pet.model.ActiveCompanionPet;
+import com.x1f4r.mmocraft.pet.model.CompanionPetDefinition;
+import com.x1f4r.mmocraft.pet.service.CompanionPetService;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.Server;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LuckySpriteSummonSkillTest {
+
+    @Mock
+    private MMOCraftPlugin plugin;
+    @Mock
+    private CompanionPetService petService;
+    @Mock
+    private PlayerProfile profile;
+    @Mock
+    private Player player;
+
+    @Test
+    void execute_whenNoPetActive_summonsLuckySprite() {
+        UUID playerId = UUID.randomUUID();
+        when(plugin.getCompanionPetService()).thenReturn(petService);
+        when(profile.getPlayerUUID()).thenReturn(playerId);
+        when(petService.getActivePet(playerId)).thenReturn(Optional.empty());
+
+        World world = mock(World.class);
+        Location location = new Location(world, 0, 64, 0);
+        when(player.getLocation()).thenReturn(location);
+        when(player.getWorld()).thenReturn(world);
+        lenient().doNothing().when(world).spawnParticle(Mockito.any(Particle.class), Mockito.any(Location.class), Mockito.anyInt(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble());
+        lenient().doNothing().when(world).playSound(Mockito.any(Location.class), Mockito.any(Sound.class), Mockito.anyFloat(), Mockito.anyFloat());
+        doNothing().when(profile).consumeMana(Mockito.anyLong());
+        when(player.getUniqueId()).thenReturn(playerId);
+
+        try (MockedStatic<Bukkit> mockedBukkit = Mockito.mockStatic(Bukkit.class)) {
+            mockedBukkit.when(() -> Bukkit.getPlayer(playerId)).thenReturn(player);
+
+            LuckySpriteSummonSkill skill = new LuckySpriteSummonSkill(plugin);
+            skill.execute(profile, null, null);
+
+            ArgumentCaptor<CompanionPetDefinition> definitionCaptor = ArgumentCaptor.forClass(CompanionPetDefinition.class);
+            verify(petService).summonPet(eq(player), definitionCaptor.capture());
+            assertEquals(DemoCompanionPets.LUCKY_SPRITE_ID, definitionCaptor.getValue().id());
+        }
+    }
+
+    @Test
+    void execute_whenPetActive_dismissesWithoutMana() {
+        UUID playerId = UUID.randomUUID();
+        when(plugin.getCompanionPetService()).thenReturn(petService);
+        when(profile.getPlayerUUID()).thenReturn(playerId);
+
+        World world = mock(World.class);
+        Location location = new Location(world, 0, 64, 0);
+        when(player.getLocation()).thenReturn(location);
+        when(player.getWorld()).thenReturn(world);
+        when(player.getUniqueId()).thenReturn(playerId);
+        CompanionPetDefinition definition = DemoCompanionPets.luckySprite();
+        ActiveCompanionPet activePet = new ActiveCompanionPet(playerId, null, definition, "status:lucky_sprite");
+        when(petService.getActivePet(playerId)).thenReturn(Optional.of(activePet));
+
+        Server server = mock(Server.class);
+        BukkitScheduler scheduler = mock(BukkitScheduler.class);
+        when(plugin.getServer()).thenReturn(server);
+        when(server.getScheduler()).thenReturn(scheduler);
+        when(scheduler.runTask(eq(plugin), any(Runnable.class))).thenAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(1);
+            runnable.run();
+            return mock(BukkitTask.class);
+        });
+
+        try (MockedStatic<Bukkit> mockedBukkit = Mockito.mockStatic(Bukkit.class)) {
+            mockedBukkit.when(() -> Bukkit.getPlayer(playerId)).thenReturn(player);
+
+            LuckySpriteSummonSkill skill = new LuckySpriteSummonSkill(plugin);
+            skill.execute(profile, null, null);
+
+            verify(petService).dismissPet(player);
+            verify(profile, times(0)).consumeMana(Mockito.anyLong());
+            verify(profile).setSkillCooldown(LuckySpriteSummonSkill.SKILL_ID, 0);
+        }
+    }
+}
+

--- a/src/test/java/com/x1f4r/mmocraft/demo/statuseffect/BerserkerRageStatusEffectTest.java
+++ b/src/test/java/com/x1f4r/mmocraft/demo/statuseffect/BerserkerRageStatusEffectTest.java
@@ -1,0 +1,91 @@
+package com.x1f4r.mmocraft.demo.statuseffect;
+
+import com.x1f4r.mmocraft.core.MMOCraftPlugin;
+import com.x1f4r.mmocraft.playerdata.model.PlayerProfile;
+import com.x1f4r.mmocraft.playerdata.model.Stat;
+import com.x1f4r.mmocraft.playerdata.runtime.PlayerRuntimeAttributeService;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BerserkerRageStatusEffectTest {
+
+    @Mock
+    private MMOCraftPlugin plugin;
+    @Mock
+    private PlayerRuntimeAttributeService runtimeAttributeService;
+    @Mock
+    private Player player;
+    @Mock
+    private PlayerProfile profile;
+
+    @Test
+    void onApply_setsTemporaryModifiersAndSyncsAttributes() {
+        when(plugin.getPlayerRuntimeAttributeService()).thenReturn(runtimeAttributeService);
+
+        World world = mock(World.class);
+        Location location = new Location(world, 0, 70, 0);
+        when(player.getLocation()).thenReturn(location);
+        when(player.getWorld()).thenReturn(world);
+        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+        lenient().doNothing().when(world).spawnParticle(Mockito.any(Particle.class), Mockito.any(Location.class), Mockito.anyInt(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble());
+        lenient().doNothing().when(world).playSound(Mockito.any(Location.class), Mockito.any(Sound.class), Mockito.anyFloat(), Mockito.anyFloat());
+
+        BerserkerRageStatusEffect effect = new BerserkerRageStatusEffect(plugin, player.getUniqueId());
+        ArgumentCaptor<Map<Stat, Double>> modifierCaptor = ArgumentCaptor.forClass(Map.class);
+
+        effect.onApply(player, profile);
+
+        verify(profile).setTemporaryStatModifiers(Mockito.eq("status:berserker_rage"), modifierCaptor.capture());
+        Map<Stat, Double> applied = modifierCaptor.getValue();
+        assertEquals(80.0, applied.get(Stat.STRENGTH));
+        assertEquals(35.0, applied.get(Stat.ATTACK_SPEED));
+        assertEquals(40.0, applied.get(Stat.FEROCITY));
+        assertEquals(-20.0, applied.get(Stat.DEFENSE));
+        assertTrue(applied.containsKey(Stat.CRITICAL_DAMAGE));
+        verify(profile).recalculateDerivedAttributes();
+        verify(runtimeAttributeService).syncPlayer(player);
+    }
+
+    @Test
+    void onExpire_clearsModifiersAndSyncs() {
+        when(plugin.getPlayerRuntimeAttributeService()).thenReturn(runtimeAttributeService);
+
+        World world = mock(World.class);
+        Location location = new Location(world, 0, 70, 0);
+        when(player.getLocation()).thenReturn(location);
+        when(player.getWorld()).thenReturn(world);
+        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+        lenient().doNothing().when(world).spawnParticle(Mockito.any(Particle.class), Mockito.any(Location.class), Mockito.anyInt(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble(), Mockito.anyDouble());
+        lenient().doNothing().when(world).playSound(Mockito.any(Location.class), Mockito.any(Sound.class), Mockito.anyFloat(), Mockito.anyFloat());
+
+        BerserkerRageStatusEffect effect = new BerserkerRageStatusEffect(plugin, player.getUniqueId());
+        effect.onExpire(player, profile);
+
+        verify(profile).clearTemporaryStatModifiers("status:berserker_rage");
+        verify(profile).recalculateDerivedAttributes();
+        verify(runtimeAttributeService).syncPlayer(player);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add player HUD service, register new listeners, and start recurring tasks for HUD/pet updates
- implement companion pet system plus Lucky Sprite summon skill and Lucky Charm hooks
- wire berserker rage status effect, custom item ability casting, and mob nameplate display

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ce6ef8050883298ffdab755d818361